### PR TITLE
Fixed Github Actions issue with CMake on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
   windows-msvc:
     name: Windows MSVC build & test
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: code-style-check
     steps:
     - uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
       run: |
         md build && cd build
         cmake --help
-        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..
+        cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..
         cmake --build .
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       shell: cmd
       run: |
         md build && cd build
-        cmake -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..
+        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..
         cmake --build .
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       shell: cmd
       run: |
         md build && cd build
-        cmake --help
         cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..
         cmake --build .
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       shell: cmd
       run: |
         md build && cd build
+        cmake --help
         cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=%BUILD_TYPE% ..
         cmake --build .
     - name: Run tests


### PR DESCRIPTION
CMake with VS 2019 generator stopped working for unknown reason. However, VS 2022 generator works pretty well.