### PR TITLE
Use raw pointers to Operation instead of shared_ptr

### DIFF
--- a/compiler/include/compiler/backend/optree/optimizer/opt_builder.hpp
+++ b/compiler/include/compiler/backend/optree/optimizer/opt_builder.hpp
@@ -11,7 +11,7 @@ namespace optimizer {
 class OptBuilder : public Builder {
   public:
     struct Notifier {
-        using Callback = std::function<void(const Operation::Ptr &)>;
+        using Callback = std::function<void(Operation *)>;
 
         Callback onInsert;
         Callback onUpdate;
@@ -23,10 +23,10 @@ class OptBuilder : public Builder {
     OptBuilder(OptBuilder &&) = default;
     ~OptBuilder() override = default;
 
-    void insert(const Operation::Ptr &op) override;
-    Operation::Ptr clone(const Operation::Ptr &op);
-    void erase(const Operation::Ptr &op);
-    void update(const Operation::Ptr &op, const std::function<void()> &actor);
+    void insert(Operation *op) override;
+    Operation *clone(Operation *op);
+    void erase(Operation *op);
+    void update(Operation *op, const std::function<void()> &actor);
 
   private:
     const Notifier &notifier;

--- a/compiler/include/compiler/backend/optree/optimizer/transform.hpp
+++ b/compiler/include/compiler/backend/optree/optimizer/transform.hpp
@@ -17,8 +17,8 @@ struct BaseTransform {
     BaseTransform(BaseTransform &&) = default;
     virtual ~BaseTransform() = default;
 
-    virtual bool canRun(const Operation::Ptr &op) const = 0;
-    virtual void run(const Operation::Ptr &op, OptBuilder &builder) const = 0;
+    virtual bool canRun(Operation *op) const = 0;
+    virtual void run(Operation *op, OptBuilder &builder) const = 0;
 };
 
 template <typename... AdaptorTypes>
@@ -28,7 +28,7 @@ struct Transform : public BaseTransform {
     Transform(Transform &&) = default;
     ~Transform() override = default;
 
-    bool canRun(const Operation::Ptr &op) const final {
+    bool canRun(Operation *op) const final {
         if constexpr (sizeof...(AdaptorTypes) == 0)
             return true;
         else

--- a/compiler/include/compiler/frontend/converter/converter_context.hpp
+++ b/compiler/include/compiler/frontend/converter/converter_context.hpp
@@ -23,7 +23,7 @@ struct ConverterContext {
         bool needsLoad = true;
     };
 
-    optree::Operation::Ptr op;
+    optree::Operation *op;
     std::unordered_map<std::string, optree::Type::Ptr> functions;
     std::forward_list<std::unordered_map<std::string, LocalVariable>> variables;
     optree::Builder builder;
@@ -34,7 +34,7 @@ struct ConverterContext {
         return builder.insert<AdaptorType>(std::forward<Args>(args)...);
     }
 
-    void goInto(const optree::Operation::Ptr &rootOp) {
+    void goInto(optree::Operation *rootOp) {
         op = rootOp;
         builder.setInsertPointAtBodyEnd(op);
     }

--- a/compiler/include/compiler/optree/base_adaptor.hpp
+++ b/compiler/include/compiler/optree/base_adaptor.hpp
@@ -58,20 +58,20 @@
 namespace optree {
 
 struct Adaptor {
-    Operation::Ptr op;
+    Operation *op;
 
     Adaptor(const Adaptor &) = default;
     Adaptor(Adaptor &&) = default;
     ~Adaptor() = default;
 
     Adaptor() : op(nullptr){};
-    Adaptor(const Operation::Ptr &op) : op(op){};
+    Adaptor(Operation *op) : op(op){};
 
     Adaptor &operator=(const Adaptor &) = default;
     Adaptor &operator=(Adaptor &&) = default;
 
     operator bool() const {
-        return op.operator bool();
+        return op != nullptr;
     }
 
     const utils::SourceRef &ref() const {

--- a/compiler/include/compiler/optree/builder.hpp
+++ b/compiler/include/compiler/optree/builder.hpp
@@ -9,11 +9,10 @@ namespace optree {
 class Builder {
     using InsertPoint = Operation::Body::iterator;
 
-    Operation::Ptr currentOp;
+    Operation *currentOp;
     InsertPoint insertPoint;
 
-    Builder(const Operation::Ptr &currentOp, const InsertPoint &insertPoint)
-        : currentOp(currentOp), insertPoint(insertPoint){};
+    Builder(Operation *currentOp, const InsertPoint &insertPoint) : currentOp(currentOp), insertPoint(insertPoint){};
 
   public:
     Builder() = default;
@@ -21,17 +20,17 @@ class Builder {
     Builder(Builder &&) = default;
     virtual ~Builder() = default;
 
-    static Builder before(const Operation::Ptr &op);
-    static Builder after(const Operation::Ptr &op);
-    static Builder atBodyBegin(const Operation::Ptr &op);
-    static Builder atBodyEnd(const Operation::Ptr &op);
+    static Builder before(Operation *op);
+    static Builder after(Operation *op);
+    static Builder atBodyBegin(Operation *op);
+    static Builder atBodyEnd(Operation *op);
 
-    void setInsertPointBefore(const Operation::Ptr &op);
-    void setInsertPointAfter(const Operation::Ptr &op);
-    void setInsertPointAtBodyBegin(const Operation::Ptr &op);
-    void setInsertPointAtBodyEnd(const Operation::Ptr &op);
+    void setInsertPointBefore(Operation *op);
+    void setInsertPointAfter(Operation *op);
+    void setInsertPointAtBodyBegin(Operation *op);
+    void setInsertPointAtBodyEnd(Operation *op);
 
-    virtual void insert(const Operation::Ptr &op);
+    virtual void insert(Operation *op);
 
     template <typename AdaptorType, typename... Args>
     AdaptorType insert(Args... args) {

--- a/compiler/include/compiler/optree/program.hpp
+++ b/compiler/include/compiler/optree/program.hpp
@@ -5,12 +5,12 @@
 namespace optree {
 
 struct Program {
-    Operation::Ptr root;
+    Operation *root;
 
     Program() = default;
     Program(const Program &) = default;
     Program(Program &&) = default;
-    ~Program() = default;
+    ~Program();
 };
 
 } // namespace optree

--- a/compiler/lib/backend/optree/optimizer/opt_builder.cpp
+++ b/compiler/lib/backend/optree/optimizer/opt_builder.cpp
@@ -8,18 +8,18 @@
 using namespace optree;
 using namespace optree::optimizer;
 
-void OptBuilder::insert(const Operation::Ptr &op) {
+void OptBuilder::insert(Operation *op) {
     Builder::insert(op);
     notifier.onInsert(op);
 }
 
-Operation::Ptr OptBuilder::clone(const Operation::Ptr &op) {
+Operation *OptBuilder::clone(Operation *op) {
     // TODO
     notifier.onInsert(op);
     return op;
 }
 
-void OptBuilder::erase(const Operation::Ptr &op) {
+void OptBuilder::erase(Operation *op) {
     if (op->parent)
         setInsertPointAfter(op);
     for (const auto &nestedOp : op->body)
@@ -28,7 +28,7 @@ void OptBuilder::erase(const Operation::Ptr &op) {
     notifier.onErase(op);
 }
 
-void OptBuilder::update(const Operation::Ptr &op, const std::function<void()> &actor) {
+void OptBuilder::update(Operation *op, const std::function<void()> &actor) {
     actor();
     notifier.onUpdate(op);
 }

--- a/compiler/lib/backend/optree/optimizer/transforms/erase_unused_ops.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/erase_unused_ops.cpp
@@ -15,7 +15,7 @@ namespace {
 struct EraseUnusedOps : public Transform<ConstantOp, ArithBinaryOp, ArithCastOp, LogicBinaryOp, LogicUnaryOp> {
     using Transform::Transform;
 
-    void run(const Operation::Ptr &op, OptBuilder &builder) const override {
+    void run(Operation *op, OptBuilder &builder) const override {
         bool unused = true;
         for (const auto &result : op->results)
             unused &= result->uses.empty();

--- a/compiler/lib/optree/builder.cpp
+++ b/compiler/lib/optree/builder.cpp
@@ -6,35 +6,35 @@
 
 using namespace optree;
 
-Builder Builder::before(const Operation::Ptr &op) {
+Builder Builder::before(Operation *op) {
     return {op->parent, op->position};
 }
 
-Builder Builder::after(const Operation::Ptr &op) {
+Builder Builder::after(Operation *op) {
     return {op->parent, std::next(op->position)};
 }
 
-Builder Builder::atBodyBegin(const Operation::Ptr &op) {
+Builder Builder::atBodyBegin(Operation *op) {
     if (op->body.empty())
         return atBodyEnd(op);
     return {op, std::next(op->body.begin())};
 }
 
-Builder Builder::atBodyEnd(const Operation::Ptr &op) {
+Builder Builder::atBodyEnd(Operation *op) {
     return {op, op->body.end()};
 }
 
-void Builder::setInsertPointBefore(const Operation::Ptr &op) {
+void Builder::setInsertPointBefore(Operation *op) {
     currentOp = op->parent;
     insertPoint = op->position;
 }
 
-void Builder::setInsertPointAfter(const Operation::Ptr &op) {
+void Builder::setInsertPointAfter(Operation *op) {
     currentOp = op->parent;
     insertPoint = std::next(op->position);
 }
 
-void Builder::setInsertPointAtBodyBegin(const Operation::Ptr &op) {
+void Builder::setInsertPointAtBodyBegin(Operation *op) {
     if (op->body.empty()) {
         setInsertPointAtBodyEnd(op);
         return;
@@ -43,12 +43,12 @@ void Builder::setInsertPointAtBodyBegin(const Operation::Ptr &op) {
     insertPoint = std::next(op->body.begin());
 }
 
-void Builder::setInsertPointAtBodyEnd(const Operation::Ptr &op) {
+void Builder::setInsertPointAtBodyEnd(Operation *op) {
     currentOp = op;
     insertPoint = op->body.end();
 }
 
-void Builder::insert(const Operation::Ptr &op) {
+void Builder::insert(Operation *op) {
     auto it = currentOp->body.insert(insertPoint, op);
     op->parent = currentOp;
     op->position = it;

--- a/compiler/lib/optree/program.cpp
+++ b/compiler/lib/optree/program.cpp
@@ -1,0 +1,13 @@
+#include "program.hpp"
+
+#include "adaptors.hpp"
+#include "operation.hpp"
+
+using namespace optree;
+
+Program::~Program() {
+    if (root)
+        root->erase();
+    // Create any operation to force storage cleanup
+    root = Operation::make<ModuleOp>().op;
+}


### PR DESCRIPTION
Operation instances are managed through internal storage which is able to destroy outdated objects automatically.