### PR TITLE
Implement operand management and cloning methods for operations

### DIFF
--- a/compiler/include/compiler/optree/adaptors.hpp
+++ b/compiler/include/compiler/optree/adaptors.hpp
@@ -31,7 +31,7 @@ struct ModuleOp : Adaptor {
         requires std::convertible_to<decltype(std::declval<AdaptorType>().name()), std::string>
     AdaptorType lookup(const std::string &name) const {
         for (const auto &childOp : op->body) {
-            if (AdaptorType adapted = Operation::as<AdaptorType>(childOp)) {
+            if (AdaptorType adapted = childOp->as<AdaptorType>()) {
                 if (adapted.name() == name)
                     return adapted;
             }

--- a/compiler/include/compiler/optree/attribute.hpp
+++ b/compiler/include/compiler/optree/attribute.hpp
@@ -21,6 +21,9 @@ struct Attribute {
     Attribute(Attribute &&) = default;
     ~Attribute() = default;
 
+    Attribute &operator=(const Attribute &) = default;
+    Attribute &operator=(Attribute &&) = default;
+
     template <typename VariantType>
     explicit Attribute(const VariantType &value) : storage(value){};
 

--- a/compiler/include/compiler/optree/base_adaptor.hpp
+++ b/compiler/include/compiler/optree/base_adaptor.hpp
@@ -74,18 +74,6 @@ struct Adaptor {
         return op.operator bool();
     }
 
-    operator const Operation::Ptr &() const {
-        return op;
-    }
-
-    operator Operation::Ptr() const {
-        return op;
-    }
-
-    Operation *operator->() const {
-        return op.get();
-    }
-
     const utils::SourceRef &ref() const {
         return op->ref;
     }

--- a/compiler/include/compiler/optree/base_adaptor.hpp
+++ b/compiler/include/compiler/optree/base_adaptor.hpp
@@ -74,6 +74,18 @@ struct Adaptor {
         return op.operator bool();
     }
 
+    operator const Operation::Ptr &() const {
+        return op;
+    }
+
+    operator Operation::Ptr() const {
+        return op;
+    }
+
+    Operation *operator->() const {
+        return op.get();
+    }
+
     const utils::SourceRef &ref() const {
         return op->ref;
     }

--- a/compiler/include/compiler/optree/operation.hpp
+++ b/compiler/include/compiler/optree/operation.hpp
@@ -42,6 +42,8 @@ struct Operation : public std::enable_shared_from_this<Operation> {
     Ptr cloneImpl(const ValueMapping &operandsMap = {});
     Ptr cloneWithoutBodyImpl(const ValueMapping &operandsMap, ValueMapping &outputsMap);
 
+    static SpecId getUnknownSpecId();
+
   public:
     Ptr parent;
     Body::iterator position;
@@ -170,12 +172,15 @@ struct Operation : public std::enable_shared_from_this<Operation> {
 
     std::string dump() const;
     void dump(std::ostream &stream) const;
+    bool isUnknown() const;
 
     template <typename AdaptorType>
     static AdaptorType make(const Ptr &parent = {}, const Body::iterator &position = {}) {
         auto *op = new Operation(AdaptorType::getSpecId(), AdaptorType::getOperationName(), parent, position);
         return {Operation::Ptr(op)};
     }
+
+    static Ptr make(std::string_view name, const Ptr &parent = {}, const Body::iterator &position = {});
 };
 
 } // namespace optree

--- a/compiler/include/compiler/optree/operation.hpp
+++ b/compiler/include/compiler/optree/operation.hpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "compiler/utils/source_ref.hpp"
@@ -24,6 +25,8 @@ struct Operation : public std::enable_shared_from_this<Operation> {
     using SpecId = void *;
 
   private:
+    using ValueMapping = std::unordered_map<Value::Ptr, Value::Ptr>;
+
     SpecId specId;
 
     explicit Operation(const Ptr &parent = nullptr, const Body::iterator &position = {})
@@ -35,6 +38,9 @@ struct Operation : public std::enable_shared_from_this<Operation> {
     void addUse(const Value::Ptr &value, size_t operandNumber);
     void removeUse(const Value::Ptr &value, size_t operandNumber);
     void updateUse(const Value::Ptr &value, size_t operandNumber, const std::function<void(Value::Use &)> &actor);
+
+    Ptr cloneImpl(const ValueMapping &operandsMap = {});
+    Ptr cloneWithoutBodyImpl(const ValueMapping &operandsMap, ValueMapping &outputsMap);
 
   public:
     Ptr parent;

--- a/compiler/include/compiler/optree/operation.hpp
+++ b/compiler/include/compiler/optree/operation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include <list>
 #include <memory>
 #include <ostream>
@@ -17,14 +18,27 @@
 
 namespace optree {
 
-struct Operation {
+struct Operation : public std::enable_shared_from_this<Operation> {
     using Ptr = std::shared_ptr<Operation>;
     using Body = std::list<Ptr>;
     using SpecId = void *;
 
+  private:
+    SpecId specId;
+
+    explicit Operation(const Ptr &parent = nullptr, const Body::iterator &position = {})
+        : parent(parent), position(position), specId(nullptr){};
+    explicit Operation(SpecId specId, std::string_view name = "Unknown", const Ptr &parent = nullptr,
+                       const Body::iterator &position = {})
+        : specId(specId), parent(parent), position(position), ref(), name(name){};
+
+    void addUse(const Value::Ptr &value, size_t operandNumber);
+    void removeUse(const Value::Ptr &value, size_t operandNumber);
+    void updateUse(const Value::Ptr &value, size_t operandNumber, const std::function<void(Value::Use &)> &actor);
+
+  public:
     Ptr parent;
     Body::iterator position;
-    SpecId specId;
     utils::SourceRef ref;
     std::string_view name;
 
@@ -35,14 +49,8 @@ struct Operation {
     Body body;
 
     Operation(const Operation &) = delete;
-    Operation(Operation &&) = default;
+    Operation(Operation &&) = delete;
     ~Operation() = default;
-
-    explicit Operation(const Ptr &parent = {}, const Body::iterator &position = {})
-        : parent(parent), position(position), specId(nullptr){};
-    Operation(SpecId specId, std::string_view name = "Unknown", const Ptr &parent = {},
-              const Body::iterator &position = {})
-        : parent(parent), position(position), specId(specId), name(name){};
 
     const Value::Ptr &operand(size_t index) const {
         return operands[index];
@@ -118,6 +126,13 @@ struct Operation {
     }
 
     template <typename AdaptorType>
+    AdaptorType as() {
+        if (is<AdaptorType>())
+            return AdaptorType(shared_from_this());
+        return {};
+    }
+
+    template <typename AdaptorType>
     AdaptorType findParent() const {
         Ptr upperParent = parent;
         while (upperParent && !upperParent->is<AdaptorType>()) {
@@ -134,25 +149,26 @@ struct Operation {
     }
 
     void addOperand(const Value::Ptr &value);
+    void insertOperand(size_t operandNumber, const Value::Ptr &value);
+    void setOperand(size_t operandNumber, const Value::Ptr &value);
     void eraseOperand(size_t operandNumber);
+
     Value::Ptr addResult(const Type::Ptr &type);
     Value::Ptr addInward(const Type::Ptr &type);
-    Body::iterator addToBody(const Operation::Ptr &op);
+
+    void addToBody(const Ptr &op);
     void erase();
+
+    Ptr clone();
+    Ptr cloneWithoutBody();
 
     std::string dump() const;
     void dump(std::ostream &stream) const;
 
     template <typename AdaptorType>
     static AdaptorType make(const Ptr &parent = {}, const Body::iterator &position = {}) {
-        return std::make_shared<Operation>(AdaptorType::getSpecId(), AdaptorType::getOperationName(), parent, position);
-    }
-
-    template <typename AdaptorType>
-    static AdaptorType as(const Operation::Ptr &op) {
-        if (op->is<AdaptorType>())
-            return AdaptorType(op);
-        return {};
+        auto *op = new Operation(AdaptorType::getSpecId(), AdaptorType::getOperationName(), parent, position);
+        return {Operation::Ptr(op)};
     }
 };
 

--- a/compiler/lib/optree/operation.cpp
+++ b/compiler/lib/optree/operation.cpp
@@ -75,8 +75,8 @@ Operation::SpecId Operation::getUnknownSpecId() {
 }
 
 void Operation::addOperand(const Value::Ptr &value) {
-    operands.emplace_back(value);
     addUse(value, operands.size());
+    operands.emplace_back(value);
 }
 
 void Operation::insertOperand(size_t operandNumber, const Value::Ptr &value) {

--- a/compiler/lib/optree/operation.cpp
+++ b/compiler/lib/optree/operation.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 

--- a/compiler/lib/optree/operation.cpp
+++ b/compiler/lib/optree/operation.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "compiler/utils/helpers.hpp"
 
@@ -65,6 +66,11 @@ Operation::Ptr Operation::cloneWithoutBodyImpl(const ValueMapping &operandsMap, 
         outputsMap[inward(i)] = newOp->inward(i);
     newOp->attributes = attributes;
     return newOp;
+}
+
+Operation::SpecId Operation::getUnknownSpecId() {
+    static char unknownSpec;
+    return &unknownSpec;
 }
 
 void Operation::addOperand(const Value::Ptr &value) {
@@ -189,4 +195,12 @@ void Operation::dump(std::ostream &stream) const {
     std::unordered_map<const Value *, int> valueIds;
     int valueId = 0;
     dumpOperation(this, stream, 0, valueIds, valueId);
+}
+
+bool Operation::isUnknown() const {
+    return specId == getUnknownSpecId();
+}
+
+Operation::Ptr Operation::make(std::string_view name, const Ptr &parent, const Body::iterator &position) {
+    return Ptr(new Operation(getUnknownSpecId(), name, parent, position));
 }

--- a/compiler/lib/optree/value.cpp
+++ b/compiler/lib/optree/value.cpp
@@ -1,5 +1,7 @@
 #include "value.hpp"
 
+#include <cstddef>
+
 #include "compiler/utils/source_ref.hpp"
 
 #include "operation.hpp"

--- a/compiler/lib/optree/value.cpp
+++ b/compiler/lib/optree/value.cpp
@@ -7,5 +7,16 @@
 using namespace optree;
 
 const utils::SourceRef &Value::ref() const {
-    return owner->ref;
+    return owner.lock()->ref;
+}
+
+Value::Use::Use(const BackRef &user, size_t operandNumber) : user(user), operandNumber(operandNumber) {
+}
+
+Operation::Ptr Value::Use::lock() const noexcept {
+    return user.lock();
+}
+
+bool Value::Use::userIs(const Operation *op) const noexcept {
+    return lock().get() == op;
 }


### PR DESCRIPTION
Operation class was enhanced with `std::enable_shared_from_this` capability to make Value class be able to hold useful operation references in `std::weak_ptr` instead of read-only raw pointers. 