### PR TITLE
Add declarative operation tree description for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
         run: tar xf binaries.tar
       - name: Run AST interface tests
         run: ./bin/ast_test
+      - name: Run operation tree interface tests
+        run: ./bin/optree_test
       - name: Run frontend tests
         run: ./bin/frontend_test
       - name: Run AST-based backend tests

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+
+#include "compiler/optree/attribute.hpp"
+#include "compiler/optree/builder.hpp"
+#include "compiler/optree/operation.hpp"
+#include "compiler/optree/program.hpp"
+#include "compiler/optree/types.hpp"
+#include "compiler/optree/value.hpp"
+
+namespace optree {
+
+class DeclarativeValue {
+    friend class DeclarativeModule;
+
+    Value::Ptr value;
+
+  public:
+    DeclarativeValue() = default;
+    DeclarativeValue(const DeclarativeValue &) = default;
+    DeclarativeValue(DeclarativeValue &&) = default;
+    ~DeclarativeValue() = default;
+
+    DeclarativeValue(const Value::Ptr &value) : value(value){};
+
+    DeclarativeValue &operator=(const DeclarativeModule &mod);
+
+    operator const Value::Ptr &() const {
+        return value;
+    }
+};
+
+class ValueStorage {
+    std::unordered_map<int, DeclarativeValue> numKeyStorage;
+    std::unordered_map<std::string_view, DeclarativeValue> strKeyStorage;
+
+  protected:
+    friend class DeclarativeModule;
+
+    ValueStorage() = default;
+    ValueStorage(const ValueStorage &) = default;
+    ValueStorage(ValueStorage &&) = default;
+    ~ValueStorage() = default;
+
+  public:
+    const DeclarativeValue &operator[](int key) const {
+        return numKeyStorage.at(key);
+    }
+
+    DeclarativeValue &operator[](int key) {
+        return numKeyStorage[key];
+    }
+
+    const DeclarativeValue &operator[](std::string_view key) const {
+        return strKeyStorage.at(key);
+    }
+
+    DeclarativeValue &operator[](std::string_view key) {
+        return strKeyStorage[key];
+    }
+};
+
+class DeclarativeModule {
+    Operation::Ptr root;
+    Operation::Ptr current;
+    Builder builder;
+    ValueStorage valueStorage;
+
+  protected:
+    friend class DeclarativeValue;
+
+    Value::Ptr currentResult(size_t index = 0) const {
+        return current->result(index);
+    }
+
+  public:
+    DeclarativeModule();
+    DeclarativeModule(const DeclarativeModule &) = delete;
+    DeclarativeModule(DeclarativeModule &&) = delete;
+    ~DeclarativeModule() = default;
+
+    const Type::Ptr tNone;
+    const Type::Ptr tI64;
+    const Type::Ptr tBool;
+    const Type::Ptr tF64;
+    const Type::Ptr tStr;
+    Type::Ptr tPtr(const Type::Ptr &pointee) const;
+    Type::Ptr tFunc(const Type::Ptr &result) const;
+    Type::Ptr tFunc(Type::PtrVector &&arguments, const Type::Ptr &result) const;
+
+    ValueStorage &values();
+
+    template <typename AdaptorType>
+    DeclarativeModule &op() {
+        current = Operation::make<AdaptorType>();
+        builder.insert(current);
+        return *this;
+    }
+
+    template <typename AdaptorType, std::convertible_to<DeclarativeValue>... DeclarativeValues>
+    DeclarativeModule &op(const DeclarativeValues &...operandValues) {
+        op<AdaptorType>();
+        return operands(operandValues...);
+    }
+
+    template <typename... DeclarativeValues>
+    DeclarativeModule &operands(const DeclarativeValue &operand, const DeclarativeValues &...other) {
+        current->addOperand(operand);
+        if constexpr (sizeof...(DeclarativeValues) != 0)
+            operands(other...);
+        return *this;
+    }
+
+    template <typename T>
+    DeclarativeModule &attr(const T &value) {
+        if constexpr (std::is_same_v<std::remove_cvref_t<T>, bool>)
+            current->addAttr(value);
+        else if constexpr (std::is_same_v<std::remove_cvref_t<T>, const char *>)
+            current->addAttr(std::string(value));
+        else if constexpr (std::is_integral_v<T>)
+            current->addAttr(static_cast<int64_t>(value));
+        else if constexpr (std::is_floating_point_v<T>)
+            current->addAttr(static_cast<double>(value));
+        else
+            current->addAttr(value);
+        return *this;
+    }
+
+    DeclarativeModule &result(const Type::Ptr &type);
+    DeclarativeModule &inward(DeclarativeValue &inward, const Type::Ptr &type);
+    void withBody();
+    void endBody();
+
+    const Operation::Ptr &rootOp() const;
+    Program makeProgram() const;
+
+    std::string dump() const;
+    void dump(std::ostream &stream) const;
+};
+
+} // namespace optree

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -153,6 +153,7 @@ class DeclarativeModule {
 
     DeclarativeModule &result(const Type::Ptr &type);
     DeclarativeModule &inward(DeclarativeValue &inward, const Type::Ptr &type);
+    DeclarativeModule &inward(DeclarativeValue &inward, size_t index);
     void withBody();
     void endBody();
 

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 
-#include "compiler/optree/attribute.hpp"
 #include "compiler/optree/builder.hpp"
 #include "compiler/optree/operation.hpp"
 #include "compiler/optree/program.hpp"

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -16,6 +16,8 @@
 
 namespace optree {
 
+class DeclarativeModule;
+
 class DeclarativeValue {
     friend class DeclarativeModule;
 

--- a/compiler/lib/optree/declarative.cpp
+++ b/compiler/lib/optree/declarative.cpp
@@ -1,0 +1,71 @@
+#include "declarative.hpp"
+
+#include <ostream>
+
+#include "adaptors.hpp"
+#include "builder.hpp"
+#include "program.hpp"
+#include "types.hpp"
+
+using namespace optree;
+
+DeclarativeValue &DeclarativeValue::operator=(const DeclarativeModule &mod) {
+    value = mod.currentResult();
+    return *this;
+}
+
+DeclarativeModule::DeclarativeModule()
+    : root(Operation::make<ModuleOp>()), current(root), builder(Builder::atBodyBegin(root)),
+      tNone(TypeStorage::noneType()), tI64(TypeStorage::integerType(64U)), tBool(TypeStorage::boolType()),
+      tF64(TypeStorage::floatType(64U)), tStr(TypeStorage::strType(8U)) {
+}
+
+Type::Ptr DeclarativeModule::tPtr(const Type::Ptr &pointee) const {
+    return Type::make<PointerType>(pointee);
+}
+
+Type::Ptr DeclarativeModule::tFunc(const Type::Ptr &result) const {
+    return Type::make<FunctionType>(result);
+}
+
+Type::Ptr DeclarativeModule::tFunc(Type::PtrVector &&arguments, const Type::Ptr &result) const {
+    return Type::make<FunctionType>(arguments, result);
+}
+
+ValueStorage &DeclarativeModule::values() {
+    return valueStorage;
+}
+
+DeclarativeModule &DeclarativeModule::result(const Type::Ptr &type) {
+    current->addResult(type);
+    return *this;
+}
+
+DeclarativeModule &DeclarativeModule::inward(DeclarativeValue &inward, const Type::Ptr &type) {
+    inward.value = current->addInward(type);
+    return *this;
+}
+
+void DeclarativeModule::withBody() {
+    builder.setInsertPointAtBodyBegin(current);
+}
+
+void DeclarativeModule::endBody() {
+    builder.setInsertPointAfter(current->parent);
+}
+
+const Operation::Ptr &DeclarativeModule::rootOp() const {
+    return root;
+}
+
+Program DeclarativeModule::makeProgram() const {
+    return {root};
+}
+
+std::string DeclarativeModule::dump() const {
+    return root->dump();
+}
+
+void DeclarativeModule::dump(std::ostream &stream) const {
+    root->dump(stream);
+}

--- a/compiler/lib/optree/declarative.cpp
+++ b/compiler/lib/optree/declarative.cpp
@@ -1,5 +1,6 @@
 #include "declarative.hpp"
 
+#include <cstddef>
 #include <ostream>
 #include <string>
 
@@ -36,6 +37,16 @@ Type::Ptr DeclarativeModule::tFunc(Type::PtrVector &&arguments, const Type::Ptr 
 
 ValueStorage &DeclarativeModule::values() {
     return valueStorage;
+}
+
+DeclarativeModule &DeclarativeModule::operand(const DeclarativeValue &operandValue) {
+    current->addOperand(operandValue);
+    return *this;
+}
+
+DeclarativeModule &DeclarativeModule::operand(size_t index, const DeclarativeValue &operandValue) {
+    current->operand(index) = operandValue;
+    return *this;
 }
 
 DeclarativeModule &DeclarativeModule::result(const Type::Ptr &type) {

--- a/compiler/lib/optree/declarative.cpp
+++ b/compiler/lib/optree/declarative.cpp
@@ -51,7 +51,8 @@ void DeclarativeModule::withBody() {
 }
 
 void DeclarativeModule::endBody() {
-    builder.setInsertPointAfter(current->parent);
+    current = current->parent;
+    builder.setInsertPointAfter(current);
 }
 
 const Operation::Ptr &DeclarativeModule::rootOp() const {

--- a/compiler/lib/optree/declarative.cpp
+++ b/compiler/lib/optree/declarative.cpp
@@ -1,9 +1,11 @@
 #include "declarative.hpp"
 
 #include <ostream>
+#include <string>
 
 #include "adaptors.hpp"
 #include "builder.hpp"
+#include "operation.hpp"
 #include "program.hpp"
 #include "types.hpp"
 

--- a/compiler/lib/optree/declarative.cpp
+++ b/compiler/lib/optree/declarative.cpp
@@ -59,6 +59,11 @@ DeclarativeModule &DeclarativeModule::inward(DeclarativeValue &inward, const Typ
     return *this;
 }
 
+DeclarativeModule &DeclarativeModule::inward(DeclarativeValue &inward, size_t index) {
+    inward.value = current->inward(index);
+    return *this;
+}
+
 void DeclarativeModule::withBody() {
     builder.setInsertPointAtBodyBegin(current);
 }

--- a/compiler/tests/CMakeLists.txt
+++ b/compiler/tests/CMakeLists.txt
@@ -1,12 +1,14 @@
 cmake_minimum_required(VERSION 3.22)
 
 add_subdirectory(ast)
+add_subdirectory(optree)
 add_subdirectory(frontend)
 add_subdirectory(backend)
 
 add_custom_target(tests
 DEPENDS
     ast_test
+    optree_test
     frontend_test
     backend_ast_test
 )
@@ -14,6 +16,7 @@ DEPENDS
 add_custom_target(run_tests
 DEPENDS
     run_ast_test
+    run_optree_test
     run_frontend_test
     run_backend_ast_test
 )

--- a/compiler/tests/optree/CMakeLists.txt
+++ b/compiler/tests/optree/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.22)
+
+set(TARGET_NAME optree_test)
+
+file(GLOB_RECURSE TARGET_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+)
+
+add_executable(${TARGET_NAME} ${TARGET_SRC})
+
+target_include_directories(${TARGET_NAME} PUBLIC
+    ${COMPILER_INCLUDE_DIR}
+)
+
+target_link_libraries(${TARGET_NAME} PUBLIC
+    optree
+    gtest
+    gtest_main
+)
+
+gtest_discover_tests(${TARGET_NAME})
+
+add_custom_target(run_optree_test
+    COMMAND $<TARGET_FILE:optree_test>
+    DEPENDS optree_test
+    COMMENT "Run operation tree interface tests"
+)

--- a/compiler/tests/optree/declarative.cpp
+++ b/compiler/tests/optree/declarative.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <string_view>
 
 #include <gtest/gtest.h>
@@ -39,6 +40,26 @@ TEST_F(DeclarativeTest, can_insert_function_with_body) {
                "  Function {string : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
                "float(64)]\n"
                "    Constant {int64_t : 123} () -> (#2 : int(64))\n"
+               "    Allocate () -> (#3 : ptr(int(64)))\n"
+               "    ArithBinary {ArithBinOpKind : 1} (#2 : int(64), #1 : float(64)) -> (#4 : int(64))\n"
+               "    Store (#3 : ptr(int(64)), #4 : int(64)) -> ()\n"
+               "    Return () -> ()\n");
+}
+
+TEST_F(DeclarativeTest, can_insert_with_adapted_init) {
+    // clang-format off
+    m.opInit<FunctionOp>("myfunc", m.tFunc({m.tI64, m.tF64}, m.tNone)).inward(v[0], 0).inward(v[1], 1).withBody();
+        v[2] = m.opInit<ConstantOp>(m.tI64, int64_t(456L));
+        v[3] = m.opInit<AllocateOp>(m.tPtr(m.tI64));
+        v[4] = m.opInit<ArithBinaryOp>(ArithBinOpKind::AddI, v[2], v[1]);
+        m.opInit<StoreOp>(v[3], v[4]);
+        m.opInit<ReturnOp>();
+    m.endBody();
+    // clang-format on
+    assertDump("Module () -> ()\n"
+               "  Function {string : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
+               "float(64)]\n"
+               "    Constant {int64_t : 456} () -> (#2 : int(64))\n"
                "    Allocate () -> (#3 : ptr(int(64)))\n"
                "    ArithBinary {ArithBinOpKind : 1} (#2 : int(64), #1 : float(64)) -> (#4 : int(64))\n"
                "    Store (#3 : ptr(int(64)), #4 : int(64)) -> ()\n"

--- a/compiler/tests/optree/declarative.cpp
+++ b/compiler/tests/optree/declarative.cpp
@@ -1,0 +1,42 @@
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+#include "compiler/optree/adaptors.hpp"
+#include "compiler/optree/declarative.hpp"
+
+using namespace optree;
+
+class DeclarativeTest : public ::testing::Test {
+  protected:
+    DeclarativeModule m;
+    ValueStorage &v;
+
+  public:
+    DeclarativeTest() : m(), v(m.values()){};
+    ~DeclarativeTest() = default;
+
+    auto assertDump(std::string_view str) const {
+        ASSERT_EQ(str, m.dump());
+    }
+};
+
+TEST_F(DeclarativeTest, can_create_module) {
+    assertDump("Module () -> ()\n");
+}
+
+TEST_F(DeclarativeTest, can_insert_function_with_body) {
+    // clang-format off
+    m.op<FunctionOp>().attr("myfunc").attr(m.tFunc({m.tI64, m.tF64}, m.tNone)).inward(v[0], m.tI64).inward(v[1], m.tF64).withBody();
+        v[2] = m.op<ConstantOp>().attr(123).result(m.tI64);
+        v[3] = m.op<AllocateOp>().result(m.tPtr(m.tI64));
+        m.op<StoreOp>(v[3], v[2]);
+    m.endBody();
+    // clang-format on
+    assertDump("Module () -> ()\n"
+               "  Function {string : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
+               "float(64)]\n"
+               "    Constant {int64_t : 123} () -> (#2 : int(64))\n"
+               "    Allocate () -> (#3 : ptr(int(64)))\n"
+               "    Store (#3 : ptr(int(64)), #2 : int(64)) -> ()\n");
+}

--- a/compiler/tests/optree/declarative.cpp
+++ b/compiler/tests/optree/declarative.cpp
@@ -30,7 +30,9 @@ TEST_F(DeclarativeTest, can_insert_function_with_body) {
     m.op<FunctionOp>().attr("myfunc").attr(m.tFunc({m.tI64, m.tF64}, m.tNone)).inward(v[0], m.tI64).inward(v[1], m.tF64).withBody();
         v[2] = m.op<ConstantOp>().attr(123).result(m.tI64);
         v[3] = m.op<AllocateOp>().result(m.tPtr(m.tI64));
-        m.op<StoreOp>(v[3], v[2]);
+        v[4] = m.op<ArithBinaryOp>(v[2], v[1]).attr(ArithBinOpKind::AddI).result(m.tI64);
+        m.op<StoreOp>(v[3], v[4]);
+        m.op<ReturnOp>();
     m.endBody();
     // clang-format on
     assertDump("Module () -> ()\n"
@@ -38,5 +40,43 @@ TEST_F(DeclarativeTest, can_insert_function_with_body) {
                "float(64)]\n"
                "    Constant {int64_t : 123} () -> (#2 : int(64))\n"
                "    Allocate () -> (#3 : ptr(int(64)))\n"
-               "    Store (#3 : ptr(int(64)), #2 : int(64)) -> ()\n");
+               "    ArithBinary {ArithBinOpKind : 1} (#2 : int(64), #1 : float(64)) -> (#4 : int(64))\n"
+               "    Store (#3 : ptr(int(64)), #4 : int(64)) -> ()\n"
+               "    Return () -> ()\n");
+}
+
+TEST_F(DeclarativeTest, can_insert_nested_operations) {
+    // clang-format off
+    m.op<FunctionOp>().attr("myfunc").attr(m.tFunc({m.tF64}, m.tNone)).inward(v[0], m.tF64).withBody();
+        v[1] = m.op<ConstantOp>().attr(7.89).result(m.tF64);
+        v[2] = m.op<AllocateOp>().result(m.tPtr(m.tF64));
+        v[3] = m.op<LogicBinaryOp>(v[0], v[1]).attr(LogicBinOpKind::GreaterEqualF).result(m.tBool);
+        m.op<IfOp>(v[3]).withBody();
+          m.op<ThenOp>().withBody();
+            v[4] = m.op<ArithBinaryOp>(v[1], v[0]).attr(ArithBinOpKind::MulF).result(m.tF64);
+            m.op<StoreOp>(v[2], v[4]);
+          m.endBody();
+          m.op<ElseOp>().withBody();
+            m.op<StoreOp>(v[2], v[0]);
+          m.endBody();
+        m.endBody();
+        v[5] = m.op<LoadOp>(v[2]).result(m.tF64);
+        m.op<PrintOp>(v[5]);
+        m.op<ReturnOp>();
+    m.endBody();
+    // clang-format on
+    assertDump("Module () -> ()\n"
+               "  Function {string : myfunc, Type : func((float(64)) -> none)} () -> () [#0 : float(64)]\n"
+               "    Constant {double : 7.89} () -> (#1 : float(64))\n"
+               "    Allocate () -> (#2 : ptr(float(64)))\n"
+               "    LogicBinary {LogicBinOpKind : 12} (#0 : float(64), #1 : float(64)) -> (#3 : int(8))\n"
+               "    If (#3 : int(8)) -> ()\n"
+               "      Then () -> ()\n"
+               "        ArithBinary {ArithBinOpKind : 7} (#1 : float(64), #0 : float(64)) -> (#4 : float(64))\n"
+               "        Store (#2 : ptr(float(64)), #4 : float(64)) -> ()\n"
+               "      Else () -> ()\n"
+               "        Store (#2 : ptr(float(64)), #0 : float(64)) -> ()\n"
+               "    Load (#2 : ptr(float(64))) -> (#5 : float(64))\n"
+               "    Print (#5 : float(64)) -> ()\n"
+               "    Return () -> ()\n");
 }

--- a/compiler/tests/optree/main.cpp
+++ b/compiler/tests/optree/main.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+#include "compiler/optree/types.hpp"
+
+
+
+int main(int argc, char *argv[]) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/compiler/tests/optree/main.cpp
+++ b/compiler/tests/optree/main.cpp
@@ -1,9 +1,5 @@
 #include <gtest/gtest.h>
 
-#include "compiler/optree/types.hpp"
-
-
-
 int main(int argc, char *argv[]) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/compiler/tests/optree/type_storage.cpp
+++ b/compiler/tests/optree/type_storage.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include "compiler/optree/types.hpp"
+
+using namespace optree;
+
+TEST(TypeStorage, can_obtain_none_type) {
+    ASSERT_NO_THROW(TypeStorage::noneType());
+}
+
+TEST(TypeStorage, can_obtain_valid_none_type) {
+    ASSERT_TRUE(TypeStorage::noneType()->is<NoneType>());
+}
+
+TEST(TypeStorage, can_obtain_predictable_none_type) {
+    auto expected = Type::make<NoneType>();
+    ASSERT_EQ(*expected, *TypeStorage::noneType());
+}
+
+TEST(TypeStorage, can_obtain_integer_type) {
+    ASSERT_NO_THROW(TypeStorage::integerType(64U));
+}
+
+TEST(TypeStorage, can_obtain_valid_integer_type) {
+    ASSERT_TRUE(TypeStorage::integerType(64U)->is<IntegerType>());
+}
+
+TEST(TypeStorage, can_obtain_predictable_integer_type) {
+    auto expected = Type::make<IntegerType>(123U);
+    auto actual = TypeStorage::integerType(123U);
+    ASSERT_EQ(*expected, *actual);
+    ASSERT_EQ(expected->width, actual->width);
+}
+
+TEST(TypeStorage, can_obtain_float_type) {
+    ASSERT_NO_THROW(TypeStorage::floatType(64U));
+}
+
+TEST(TypeStorage, can_obtain_valid_float_type) {
+    ASSERT_TRUE(TypeStorage::floatType(64U)->is<FloatType>());
+}
+
+TEST(TypeStorage, can_obtain_predictable_float_type) {
+    auto expected = Type::make<FloatType>(123U);
+    auto actual = TypeStorage::floatType(123U);
+    ASSERT_EQ(*expected, *actual);
+    ASSERT_EQ(expected->width, actual->width);
+}


### PR DESCRIPTION
A DeclarativeModule class makes it possible to describe optree in a concise, *declarative* style like this:

```cpp
DeclarativeModule m;
auto &v = m.values();
m.op<FunctionOp>().attr("myfunc").attr(m.tFunc({m.tI64, m.tF64}, m.tNone)).inward(v[0], m.tI64).inward(v[1], m.tF64).withBody();
    v[2] = m.op<ConstantOp>().attr(123).result(m.tI64);
    v[3] = m.op<AllocateOp>().result(m.tPtr(m.tI64));
    v[4] = m.op<ArithBinaryOp>(v[2], v[1]).attr(ArithBinOpKind::AddI).result(m.tI64);
    m.op<StoreOp>(v[3], v[4]);
    m.op<ReturnOp>();
m.endBody();
```

Optionally, the code above can be replaced with this one which uses *adaptor initializers*:

```cpp
m.opInit<FunctionOp>("myfunc", m.tFunc({m.tI64, m.tF64}, m.tNone)).inward(v[0], 0).inward(v[1], 1).withBody();
    v[2] = m.opInit<ConstantOp>(m.tI64, 123);
    v[3] = m.opInit<AllocateOp>(m.tPtr(m.tI64));
    v[4] = m.opInit<ArithBinaryOp>(ArithBinOpKind::AddI, v[2], v[1]);
    m.opInit<StoreOp>(v[3], v[4]);
    m.opInit<ReturnOp>();
m.endBody();
```

This patch also adds test for DeclarativeModule and TypeStorage (which is used by it).