### PR TITLE
Comply InputOp and PrintOp with an SSA paradigm

### DIFF
--- a/compiler/include/compiler/optree/adaptors.hpp
+++ b/compiler/include/compiler/optree/adaptors.hpp
@@ -249,17 +249,16 @@ struct PrintOp;
 struct InputOp : Adaptor {
     OPTREE_ADAPTOR_HELPER(Adaptor, "Input")
 
-    void init(const Type::Ptr &inputType);
+    void init(const Value::Ptr &dst);
 
-    OPTREE_ADAPTOR_RESULT(value, 0)
+    OPTREE_ADAPTOR_OPERAND(dst, setDst, 0)
 };
 
 struct PrintOp : Adaptor {
     OPTREE_ADAPTOR_HELPER(Adaptor, "Print")
 
     void init(const Value::Ptr &valueToPrint);
-
-    OPTREE_ADAPTOR_OPERAND(value, setValue, 0)
+    void init(const std::vector<Value::Ptr> &valuesToPrint);
 };
 
 } // namespace optree

--- a/compiler/lib/frontend/converter/converter.cpp
+++ b/compiler/lib/frontend/converter/converter.cpp
@@ -108,8 +108,7 @@ void createInputOp(const Node::Ptr &varNameNode, const utils::SourceRef &inputRe
         ctx.pushError(varNameNode, "variable cannot be modified: " + varNameNode->str());
         return;
     }
-    auto inputOp = ctx.insert<InputOp>(inputRef, var.value->type->as<PointerType>().pointee);
-    ctx.insert<StoreOp>(inputRef, var.value, inputOp.value());
+    ctx.insert<InputOp>(inputRef, var.value);
 }
 
 void processNode(const Node::Ptr &node, ConverterContext &ctx);
@@ -346,8 +345,10 @@ Value::Ptr visitFunctionCall(const Node::Ptr &node, ConverterContext &ctx) {
             ctx.pushError(node, "print() statement cannot be within an expression context");
             throw ctx.errors;
         }
+        std::vector<Value::Ptr> arguments;
         for (auto &argNode : node->lastChild()->children)
-            ctx.insert<PrintOp>(argNode->ref, visitNode(argNode, ctx));
+            arguments.emplace_back(visitNode(argNode, ctx));
+        ctx.insert<PrintOp>(node->ref, arguments);
         return {};
     }
     if (name == "input") {

--- a/compiler/lib/optree/adaptors.cpp
+++ b/compiler/lib/optree/adaptors.cpp
@@ -111,8 +111,8 @@ ElseOp IfOp::elseOp() const {
     return {op->body.size() == 2 ? op->body.back() : nullptr};
 }
 
-void InputOp::init(const Type::Ptr &inputType) {
-    op->addResult(inputType);
+void InputOp::init(const Value::Ptr &dst) {
+    op->addOperand(dst);
 }
 
 void LoadOp::init(const Type::Ptr &resultType, const Value::Ptr &src) {
@@ -140,6 +140,11 @@ void ModuleOp::init() {
 
 void PrintOp::init(const Value::Ptr &valueToPrint) {
     op->addOperand(valueToPrint);
+}
+
+void PrintOp::init(const std::vector<Value::Ptr> &valuesToPrint) {
+    for (const auto &value : valuesToPrint)
+        op->addOperand(value);
 }
 
 void ReturnOp::init() {

--- a/compiler/tests/backend/optree/optimizer/erase_unused_ops.cpp
+++ b/compiler/tests/backend/optree/optimizer/erase_unused_ops.cpp
@@ -96,7 +96,6 @@ TEST_F(EraseUnusedOpsTest, can_keep_irrelevant_ops) {
     m.opInit<FunctionOp>("test", m.tFunc({m.tPtr(m.tI64)}, m.tNone)).inward(v[0], 0).withBody();
     v[1] = m.opInit<AllocateOp>(m.tPtr(m.tI64));
     v[2] = m.opInit<LoadOp>(v[0]);
-    v[3] = m.opInit<InputOp>(m.tI64);
     m.opInit<ReturnOp>();
     m.endBody();
 


### PR DESCRIPTION
PrintOp was made able to hold multiple operands as values to be printed.

InputOp was redesigned with an idea to have input value storing as part of an operation.

Closes #140 