### PR TITLE
Solidify native types and add type deduction for attributes

### DIFF
--- a/compiler/include/compiler/optree/adaptors.hpp
+++ b/compiler/include/compiler/optree/adaptors.hpp
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <cstdint>
 #include <string>
-#include <type_traits>
 #include <vector>
 
-#include "compiler/optree/attribute.hpp"
 #include "compiler/optree/base_adaptor.hpp"
 #include "compiler/optree/definitions.hpp"
 #include "compiler/optree/operation.hpp"

--- a/compiler/include/compiler/optree/adaptors.hpp
+++ b/compiler/include/compiler/optree/adaptors.hpp
@@ -2,8 +2,10 @@
 
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 
+#include "compiler/optree/attribute.hpp"
 #include "compiler/optree/base_adaptor.hpp"
 #include "compiler/optree/definitions.hpp"
 #include "compiler/optree/operation.hpp"
@@ -71,10 +73,11 @@ struct ReturnOp : Adaptor {
 struct ConstantOp : Adaptor {
     OPTREE_ADAPTOR_HELPER(Adaptor, "Constant")
 
-    void init(const Type::Ptr &type, int64_t value);
-    void init(const Type::Ptr &type, bool value);
-    void init(const Type::Ptr &type, double value);
-    void init(const Type::Ptr &type, const std::string &value);
+    template <typename T>
+    void init(const Type::Ptr &type, const T &value) {
+        op->results.emplace_back(Value::make(type, op));
+        op->addAttr(value);
+    }
 
     OPTREE_ADAPTOR_ATTRIBUTE_OPAQUE(value, 0)
     OPTREE_ADAPTOR_RESULT(result, 0)

--- a/compiler/include/compiler/optree/attribute.hpp
+++ b/compiler/include/compiler/optree/attribute.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <ostream>
+#include <string>
 #include <variant>
 
 #include "compiler/optree/definitions.hpp"

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -132,16 +132,7 @@ class DeclarativeModule {
 
     template <typename T>
     DeclarativeModule &attr(const T &value) {
-        if constexpr (std::is_same_v<std::remove_cvref_t<T>, bool>)
-            current->addAttr(value);
-        else if constexpr (std::is_same_v<std::remove_cvref_t<T>, const char *>)
-            current->addAttr(std::string(value));
-        else if constexpr (std::is_integral_v<T>)
-            current->addAttr(static_cast<int64_t>(value));
-        else if constexpr (std::is_floating_point_v<T>)
-            current->addAttr(static_cast<double>(value));
-        else
-            current->addAttr(value);
+        current->addAttr(value);
         return *this;
     }
 

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
+#include <concepts>
 #include <cstddef>
-#include <cstdint>
 #include <ostream>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 

--- a/compiler/include/compiler/optree/declarative.hpp
+++ b/compiler/include/compiler/optree/declarative.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <concepts>
 #include <cstddef>
 #include <ostream>
 #include <string>

--- a/compiler/include/compiler/optree/types.hpp
+++ b/compiler/include/compiler/optree/types.hpp
@@ -65,6 +65,7 @@ struct NoneType : public Type {
 
 struct IntegerType : public Type {
     using Ptr = std::shared_ptr<const IntegerType>;
+    using NativeType = int64_t;
 
     const unsigned width;
 
@@ -79,6 +80,7 @@ struct IntegerType : public Type {
 
 struct BoolType : public IntegerType {
     using Ptr = std::shared_ptr<const BoolType>;
+    using NativeType = bool;
 
     static constinit const unsigned intWidth = 8U;
 
@@ -90,6 +92,7 @@ struct BoolType : public IntegerType {
 
 struct FloatType : public Type {
     using Ptr = std::shared_ptr<const FloatType>;
+    using NativeType = double;
 
     const unsigned width;
 
@@ -104,6 +107,7 @@ struct FloatType : public Type {
 
 struct StrType : public Type {
     using Ptr = std::shared_ptr<const StrType>;
+    using NativeType = std::string;
 
     const unsigned charWidth;
 
@@ -166,5 +170,13 @@ struct TypeStorage {
     static FloatType::Ptr floatType(unsigned width = 64U);
     static StrType::Ptr strType(unsigned charWidth = 8U);
 };
+
+template <typename ConcreteType>
+using NativeType = typename ConcreteType::NativeType;
+
+using NativeInt = NativeType<IntegerType>;
+using NativeBool = NativeType<BoolType>;
+using NativeFloat = NativeType<FloatType>;
+using NativeStr = NativeType<StrType>;
 
 } // namespace optree

--- a/compiler/include/compiler/optree/types.hpp
+++ b/compiler/include/compiler/optree/types.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <ostream>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/compiler/lib/codegen/optree_to_llvmir/llvmir_generator.cpp
+++ b/compiler/lib/codegen/optree_to_llvmir/llvmir_generator.cpp
@@ -216,14 +216,14 @@ void LLVMIRGenerator::visit(const ConstantOp &op) {
     if (type->is<BoolType>())
         return result(llvm::ConstantInt::get(convertType(type), op.value().as<bool>()));
     if (type->is<IntegerType>()) {
-        auto num = op.value().as<int64_t>();
+        auto num = static_cast<int64_t>(op.value().as<NativeInt>());
         auto *value = llvm::ConstantInt::get(convertType(type), reinterpret_cast<uint64_t &>(num), /*IsSigned*/ true);
         return result(value);
     }
     if (type->is<FloatType>())
-        return result(llvm::ConstantFP::get(convertType(type), op.value().as<double>()));
+        return result(llvm::ConstantFP::get(convertType(type), static_cast<double>(op.value().as<NativeFloat>())));
     if (type->is<StrType>())
-        return result(getGlobalString(op.value().as<std::string>()));
+        return result(getGlobalString(op.value().as<NativeStr>()));
     COMPILER_UNREACHABLE("unexpected result type in ConstantOp");
 }
 

--- a/compiler/lib/frontend/converter/converter.cpp
+++ b/compiler/lib/frontend/converter/converter.cpp
@@ -222,20 +222,23 @@ Value::Ptr visitExpression(const Node::Ptr &node, ConverterContext &ctx) {
 }
 
 Value::Ptr visitIntegerLiteralValue(const Node::Ptr &node, ConverterContext &ctx) {
-    auto value = static_cast<int64_t>(node->intNum());
+    auto value = static_cast<NativeInt>(node->intNum());
     return ctx.insert<ConstantOp>(node->ref, TypeStorage::integerType(), value).result();
 }
 
 Value::Ptr visitBooleanLiteralValue(const Node::Ptr &node, ConverterContext &ctx) {
-    return ctx.insert<ConstantOp>(node->ref, TypeStorage::boolType(), node->boolean()).result();
+    auto value = static_cast<NativeBool>(node->boolean());
+    return ctx.insert<ConstantOp>(node->ref, TypeStorage::boolType(), value).result();
 }
 
 Value::Ptr visitFloatingPointLiteralValue(const Node::Ptr &node, ConverterContext &ctx) {
-    return ctx.insert<ConstantOp>(node->ref, TypeStorage::floatType(), node->fpNum()).result();
+    auto value = static_cast<NativeFloat>(node->fpNum());
+    return ctx.insert<ConstantOp>(node->ref, TypeStorage::floatType(), value).result();
 }
 
 Value::Ptr visitStringLiteralValue(const Node::Ptr &node, ConverterContext &ctx) {
-    return ctx.insert<ConstantOp>(node->ref, TypeStorage::strType(), node->str()).result();
+    auto value = static_cast<NativeStr>(node->str());
+    return ctx.insert<ConstantOp>(node->ref, TypeStorage::strType(), value).result();
 }
 
 Value::Ptr visitBinaryOperation(const Node::Ptr &node, ConverterContext &ctx) {

--- a/compiler/lib/optree/adaptors.cpp
+++ b/compiler/lib/optree/adaptors.cpp
@@ -47,26 +47,6 @@ Value::Ptr ConditionOp::terminator() const {
     return op->body.back()->result(0);
 }
 
-void ConstantOp::init(const Type::Ptr &type, int64_t value) {
-    op->results.emplace_back(Value::make(type, op));
-    op->addAttr(value);
-}
-
-void ConstantOp::init(const Type::Ptr &type, bool value) {
-    op->results.emplace_back(Value::make(type, op));
-    op->addAttr(value);
-}
-
-void ConstantOp::init(const Type::Ptr &type, double value) {
-    op->results.emplace_back(Value::make(type, op));
-    op->addAttr(value);
-}
-
-void ConstantOp::init(const Type::Ptr &type, const std::string &value) {
-    op->results.emplace_back(Value::make(type, op));
-    op->addAttr(value);
-}
-
 void ElseOp::init() {
 }
 

--- a/compiler/lib/optree/adaptors.cpp
+++ b/compiler/lib/optree/adaptors.cpp
@@ -1,6 +1,5 @@
 #include "adaptors.hpp"
 
-#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/compiler/lib/optree/attribute.cpp
+++ b/compiler/lib/optree/attribute.cpp
@@ -15,20 +15,20 @@ void Attribute::dump(std::ostream &stream) const {
         stream << "empty";
         return;
     }
-    if (is<int64_t>()) {
-        stream << "int64_t : " << as<int64_t>();
+    if (is<NativeInt>()) {
+        stream << "int : " << as<NativeInt>();
         return;
     }
-    if (is<double>()) {
-        stream << "double : " << as<double>();
+    if (is<NativeFloat>()) {
+        stream << "float : " << as<NativeFloat>();
         return;
     }
-    if (is<bool>()) {
-        stream << "bool : " << as<bool>();
+    if (is<NativeBool>()) {
+        stream << "bool : " << as<NativeBool>();
         return;
     }
-    if (is<std::string>()) {
-        stream << "string : " << as<std::string>();
+    if (is<NativeStr>()) {
+        stream << "str : " << as<NativeStr>();
         return;
     }
     if (is<Type::Ptr>()) {

--- a/compiler/tests/backend/optree/optimizer/erase_unused_ops.cpp
+++ b/compiler/tests/backend/optree/optimizer/erase_unused_ops.cpp
@@ -30,7 +30,7 @@ TEST_F(EraseUnusedOpsTest, can_erase_unused_ops) {
     {
         auto &&[m, v] = getActual();
         m.opInit<FunctionOp>("test", m.tFunc({m.tI64, m.tI64}, m.tNone)).inward(v[0], 0).inward(v[1], 1).withBody();
-        v[2] = m.opInit<ConstantOp>(m.tI64, int64_t(123));
+        v[2] = m.opInit<ConstantOp>(m.tI64, 123);
         v[3] = m.opInit<ArithBinaryOp>(ArithBinOpKind::AddI, v[0], v[1]);
         v[4] = m.opInit<ArithCastOp>(ArithCastOpKind::IntToFloat, m.tF64, v[0]);
         v[5] = m.opInit<LogicBinaryOp>(LogicBinOpKind::LessEqualI, v[0], v[1]);
@@ -52,7 +52,7 @@ TEST_F(EraseUnusedOpsTest, can_erase_chain_of_unused_ops) {
     {
         auto &&[m, v] = getActual();
         m.opInit<FunctionOp>("test", m.tFunc({m.tI64}, m.tNone)).inward(v[0], 0).withBody();
-        v[1] = m.opInit<ConstantOp>(m.tI64, int64_t(123));
+        v[1] = m.opInit<ConstantOp>(m.tI64, 123);
         v[2] = m.opInit<ArithBinaryOp>(ArithBinOpKind::AddI, v[0], v[1]);
         v[3] = m.opInit<ArithCastOp>(ArithCastOpKind::IntToFloat, m.tF64, v[2]);
         m.opInit<ReturnOp>();
@@ -72,7 +72,7 @@ TEST_F(EraseUnusedOpsTest, can_keep_used_ops) {
     auto &&[m, v] = getActual();
 
     m.opInit<FunctionOp>("test", m.tFunc({m.tI64, m.tI64}, m.tNone)).inward(v[0], 0).inward(v[1], 1).withBody();
-    v[2] = m.opInit<ConstantOp>(m.tI64, int64_t(123));
+    v[2] = m.opInit<ConstantOp>(m.tI64, 123);
     v[3] = m.opInit<ArithBinaryOp>(ArithBinOpKind::AddI, v[0], v[1]);
     v[4] = m.opInit<ArithCastOp>(ArithCastOpKind::IntToFloat, m.tF64, v[0]);
     v[5] = m.opInit<LogicBinaryOp>(LogicBinOpKind::LessEqualI, v[0], v[1]);

--- a/compiler/tests/optree/declarative.cpp
+++ b/compiler/tests/optree/declarative.cpp
@@ -37,9 +37,9 @@ TEST_F(DeclarativeTest, can_insert_function_with_body) {
     m.endBody();
     // clang-format on
     assertDump("Module () -> ()\n"
-               "  Function {string : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
+               "  Function {str : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
                "float(64)]\n"
-               "    Constant {int64_t : 123} () -> (#2 : int(64))\n"
+               "    Constant {int : 123} () -> (#2 : int(64))\n"
                "    Allocate () -> (#3 : ptr(int(64)))\n"
                "    ArithBinary {ArithBinOpKind : 1} (#2 : int(64), #1 : float(64)) -> (#4 : int(64))\n"
                "    Store (#3 : ptr(int(64)), #4 : int(64)) -> ()\n"
@@ -49,7 +49,7 @@ TEST_F(DeclarativeTest, can_insert_function_with_body) {
 TEST_F(DeclarativeTest, can_insert_with_adapted_init) {
     // clang-format off
     m.opInit<FunctionOp>("myfunc", m.tFunc({m.tI64, m.tF64}, m.tNone)).inward(v[0], 0).inward(v[1], 1).withBody();
-        v[2] = m.opInit<ConstantOp>(m.tI64, int64_t(456L));
+        v[2] = m.opInit<ConstantOp>(m.tI64, 456L);
         v[3] = m.opInit<AllocateOp>(m.tPtr(m.tI64));
         v[4] = m.opInit<ArithBinaryOp>(ArithBinOpKind::AddI, v[2], v[1]);
         m.opInit<StoreOp>(v[3], v[4]);
@@ -57,9 +57,9 @@ TEST_F(DeclarativeTest, can_insert_with_adapted_init) {
     m.endBody();
     // clang-format on
     assertDump("Module () -> ()\n"
-               "  Function {string : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
+               "  Function {str : myfunc, Type : func((int(64), float(64)) -> none)} () -> () [#0 : int(64), #1 : "
                "float(64)]\n"
-               "    Constant {int64_t : 456} () -> (#2 : int(64))\n"
+               "    Constant {int : 456} () -> (#2 : int(64))\n"
                "    Allocate () -> (#3 : ptr(int(64)))\n"
                "    ArithBinary {ArithBinOpKind : 1} (#2 : int(64), #1 : float(64)) -> (#4 : int(64))\n"
                "    Store (#3 : ptr(int(64)), #4 : int(64)) -> ()\n"
@@ -87,8 +87,8 @@ TEST_F(DeclarativeTest, can_insert_nested_operations) {
     m.endBody();
     // clang-format on
     assertDump("Module () -> ()\n"
-               "  Function {string : myfunc, Type : func((float(64)) -> none)} () -> () [#0 : float(64)]\n"
-               "    Constant {double : 7.89} () -> (#1 : float(64))\n"
+               "  Function {str : myfunc, Type : func((float(64)) -> none)} () -> () [#0 : float(64)]\n"
+               "    Constant {float : 7.89} () -> (#1 : float(64))\n"
                "    Allocate () -> (#2 : ptr(float(64)))\n"
                "    LogicBinary {LogicBinOpKind : 12} (#0 : float(64), #1 : float(64)) -> (#3 : int(8))\n"
                "    If (#3 : int(8)) -> ()\n"


### PR DESCRIPTION
Initialize ConstantOp using *a template function* instead of multiple overloads (therefore it should be checked to hold one of supported native types during the optree verification stage).

Introduce new helpers: `typeOneOf`, `canHoldAlternative` for variants, `advanceEarly` overload for ranges.