### PR TITLE
Add Windows MSVC build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,20 @@ jobs:
           cmake -S compiler -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_CODEGEN='ast_to_llvmir;optree_to_llvmir'
           cmake --build build --parallel
 
+  build-msvc:
+    name: Build on Windows MSVC
+    runs-on: windows-latest
+    needs: code-style-check
+    steps:
+      - name: Initialize repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Build
+        run: |
+          cmake -S compiler -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --parallel
+
   unit-test:
     name: Unit test
     runs-on: ubuntu-latest

--- a/compiler/include/compiler/utils/helpers.hpp
+++ b/compiler/include/compiler/utils/helpers.hpp
@@ -7,12 +7,18 @@
 #include <tuple>
 #include <type_traits>
 
-#if __has_builtin(__builtin_unreachable)
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC
 #define COMPILER_UNREACHABLE(MESSAGE)                                                                                  \
-    assert(false && (MESSAGE));                                                                                        \
-    __builtin_unreachable()
-#else
-#define COMPILER_UNREACHABLE(MESSAGE) assert(false && (MESSAGE))
+    do {                                                                                                               \
+        assert(false && (MESSAGE));                                                                                    \
+        __assume(false);                                                                                               \
+    } while (0)
+#else // GCC, Clang
+#define COMPILER_UNREACHABLE(MESSAGE)                                                                                  \
+    do {                                                                                                               \
+        assert(false && (MESSAGE));                                                                                    \
+        __builtin_unreachable();                                                                                       \
+    } while (0)
 #endif
 
 namespace utils {


### PR DESCRIPTION
This patch also adds MSVC support in COMPILER_UNREACHABLE macro.