### PR TITLE
Add debug printing to optree optimizer

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(NDEBUG)
+endif()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_COMPILE_WARNING_AS_ERROR ON)

--- a/compiler/include/compiler/backend/optree/optimizer/transform.hpp
+++ b/compiler/include/compiler/backend/optree/optimizer/transform.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 #include "compiler/optree/operation.hpp"
 
@@ -17,6 +18,7 @@ struct BaseTransform {
     BaseTransform(BaseTransform &&) = default;
     virtual ~BaseTransform() = default;
 
+    virtual std::string_view name() const = 0;
     virtual bool canRun(const Operation::Ptr &op) const = 0;
     virtual void run(const Operation::Ptr &op, OptBuilder &builder) const = 0;
 };

--- a/compiler/include/compiler/utils/debug.hpp
+++ b/compiler/include/compiler/utils/debug.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#pragma warning(disable : 4996)
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#if defined(NDEBUG) && !defined(DEBUG)
+#define COMPILER_DEBUG(STATEMENT)
+#else
+#define COMPILER_DEBUG(STATEMENT) STATEMENT
+#endif
+
+namespace utils {
+
+class DebugPrinter {
+    bool printerEnabled;
+
+    DebugPrinter() : printerEnabled(false) {
+        if (const char *valuePtr = std::getenv("COMPILER_DEBUG")) {
+            std::string env(valuePtr);
+            printerEnabled = (env == "1");
+        }
+    }
+    DebugPrinter(const DebugPrinter &) = delete;
+    DebugPrinter(DebugPrinter &&) = delete;
+    ~DebugPrinter() = default;
+
+  public:
+    bool enabled() const {
+        return printerEnabled;
+    }
+
+    void setEnabled(bool newValue) {
+        printerEnabled = newValue;
+    }
+
+    template <typename T>
+    DebugPrinter &operator<<(const T &object) {
+        if (printerEnabled)
+            std::cerr << object;
+        return *this;
+    }
+
+    static DebugPrinter &get() {
+        static DebugPrinter instance;
+        return instance;
+    }
+};
+
+} // namespace utils

--- a/compiler/include/compiler/utils/debug.hpp
+++ b/compiler/include/compiler/utils/debug.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+// Suppress security warning regarding some I/O functions on MSVC
 #pragma warning(disable : 4996)
 
 #include <cstdlib>

--- a/compiler/lib/backend/optree/optimizer/optimizer.cpp
+++ b/compiler/lib/backend/optree/optimizer/optimizer.cpp
@@ -6,6 +6,7 @@
 
 #include "compiler/optree/operation.hpp"
 #include "compiler/optree/program.hpp"
+#include "compiler/utils/debug.hpp"
 
 #include "optimizer/opt_builder.hpp"
 #include "optimizer/transform.hpp"
@@ -13,6 +14,8 @@
 
 using namespace optree;
 using namespace optree::optimizer;
+
+using dbg = utils::DebugPrinter;
 
 namespace {
 
@@ -149,7 +152,9 @@ void Optimizer::process(Program &program) const {
                     continue;
                 OptBuilder builder(notifier);
                 builder.setInsertPointBefore(op);
+                COMPILER_DEBUG(dbg::get() << "Run " << transform->name() << " on " << op->dump() << "{\n");
                 transform->run(op, builder);
+                COMPILER_DEBUG(dbg::get() << "}\n\n");
             }
         }
     } while (mutated && ++iter < iterLimit);

--- a/compiler/lib/backend/optree/optimizer/transforms/erase_unused_functions.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/erase_unused_functions.cpp
@@ -21,6 +21,10 @@ struct EraseUnusedFunctions : public Transform<ModuleOp> {
     using Transform::Transform;
     using CallEdges = std::map<std::string, std::unordered_set<std::string>>;
 
+    std::string_view name() const override {
+        return "EraseUnusedFunctions";
+    }
+
     void getInnerFunctionCallNames(const Operation::Ptr &op, const std::string &parentName, CallEdges &edges) const {
         for (auto &child : op->body) {
             auto funcOp = child->as<FunctionCallOp>();

--- a/compiler/lib/backend/optree/optimizer/transforms/erase_unused_functions.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/erase_unused_functions.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 
 #include "compiler/optree/adaptors.hpp"

--- a/compiler/lib/backend/optree/optimizer/transforms/erase_unused_ops.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/erase_unused_ops.cpp
@@ -1,11 +1,11 @@
-#include "optimizer/transform.hpp"
-
 #include <memory>
+#include <string_view>
 
 #include "compiler/optree/adaptors.hpp"
 #include "compiler/optree/operation.hpp"
 
 #include "optimizer/opt_builder.hpp"
+#include "optimizer/transform.hpp"
 
 using namespace optree;
 using namespace optree::optimizer;

--- a/compiler/lib/backend/optree/optimizer/transforms/erase_unused_ops.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/erase_unused_ops.cpp
@@ -15,6 +15,10 @@ namespace {
 struct EraseUnusedOps : public Transform<ConstantOp, ArithBinaryOp, ArithCastOp, LogicBinaryOp, LogicUnaryOp> {
     using Transform::Transform;
 
+    std::string_view name() const override {
+        return "EraseUnusedOps";
+    }
+
     void run(const Operation::Ptr &op, OptBuilder &builder) const override {
         bool unused = true;
         for (const auto &result : op->results)

--- a/compiler/lib/backend/optree/optimizer/transforms/fold_constants.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/fold_constants.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string_view>
 
 #include "compiler/optree/adaptors.hpp"
 #include "compiler/optree/definitions.hpp"

--- a/compiler/lib/backend/optree/optimizer/transforms/fold_constants.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/fold_constants.cpp
@@ -18,6 +18,10 @@ namespace {
 struct FoldConstants : public Transform<ArithBinaryOp, ArithCastOp, LogicBinaryOp, LogicUnaryOp> {
     using Transform::Transform;
 
+    std::string_view name() const override {
+        return "FoldConstants";
+    }
+
     static void foldArithBinaryOp(const ArithBinaryOp &op, OptBuilder &builder) {
         auto lhsOp = getValueOwnerAs<ConstantOp>(op.lhs());
         auto rhsOp = getValueOwnerAs<ConstantOp>(op.rhs());


### PR DESCRIPTION
Printing capabilities are implemented within new DebugPrinter utility class. It lives as a singleton and can enable itself automatically if `COMPILER_DEBUG` environment variable is set to `1`.

COMPILER_DEBUG macro expands to nothing if build type is other that "Debug", or to wrapped statement otherwise.