### PR TITLE
Append values to error message via operator<<

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
         run: ./bin/codegen_ast_to_llvmir_test
       - name: Run codegen tests (optree to LLVM IR)
         run: ./bin/codegen_optree_to_llvmir_test
+      - name: Run utility tests
+        run: ./bin/utils_test
 
   code-coverage:
     name: Code coverage

--- a/compiler/include/compiler/utils/base_error.hpp
+++ b/compiler/include/compiler/utils/base_error.hpp
@@ -6,12 +6,43 @@
 #include "compiler/utils/source_ref.hpp"
 
 class BaseError : public std::exception {
-    std::string what_str;
+    std::string message;
 
   public:
-    BaseError(const utils::SourceRef &ref, const std::string &message);
-    BaseError(const std::string &message);
+    BaseError(const BaseError &) = default;
+    BaseError(BaseError &&) = default;
     ~BaseError() = default;
 
+    explicit BaseError(const utils::SourceRef &ref, const std::string &initMessage = {});
+    explicit BaseError(const std::string &initMessage = {});
+
     virtual const char *what() const noexcept;
+
+    template <typename T>
+        requires std::same_as<decltype(message + std::declval<T>()), std::string>
+    BaseError &operator<<(const T &value) {
+        message += value;
+        return *this;
+    }
+
+    template <typename T>
+        requires std::same_as<decltype(message + std::to_string(std::declval<T>())), std::string>
+    BaseError &operator<<(const T &value) {
+        message += std::to_string(value);
+        return *this;
+    }
+
+    template <typename T>
+        requires std::same_as<decltype(std::declval<T>().dump()), std::string>
+    BaseError &operator<<(const T &value) {
+        message += value.dump();
+        return *this;
+    }
+
+    template <typename T>
+        requires std::same_as<decltype(std::declval<T>()->dump()), std::string>
+    BaseError &operator<<(const T &value) {
+        message += value->dump();
+        return *this;
+    }
 };

--- a/compiler/include/compiler/utils/error_buffer.hpp
+++ b/compiler/include/compiler/utils/error_buffer.hpp
@@ -16,9 +16,10 @@ class ErrorBuffer : public std::exception {
     ErrorBuffer(ErrorBuffer &&) = default;
     ~ErrorBuffer() = default;
 
-    template <typename ErrorT, typename... Args>
-    void push(Args... args) {
-        buffer.emplace_back(std::make_shared<ErrorT>(args...));
+    template <std::derived_from<BaseError> ErrorT, typename... Args>
+    std::shared_ptr<ErrorT> push(Args... args) {
+        auto &error = buffer.emplace_back(std::make_shared<ErrorT>(std::forward<Args>(args)...));
+        return std::dynamic_pointer_cast<ErrorT>(error);
     }
 
     std::string message() const {

--- a/compiler/lib/utils/base_error.cpp
+++ b/compiler/lib/utils/base_error.cpp
@@ -1,6 +1,7 @@
 #include "base_error.hpp"
 
 #include <sstream>
+#include <string>
 
 using utils::SourceRef;
 

--- a/compiler/lib/utils/base_error.cpp
+++ b/compiler/lib/utils/base_error.cpp
@@ -4,16 +4,16 @@
 
 using utils::SourceRef;
 
-BaseError::BaseError(const SourceRef &ref, const std::string &message) {
+BaseError::BaseError(const SourceRef &ref, const std::string &initMessage) {
     std::stringstream str;
-    str << "In line " << ref.line << " in column " << ref.column << " error:\n" << message;
-    what_str = str.str();
+    str << "In line " << ref.line << " in column " << ref.column << " error:\n" << initMessage;
+    message = str.str();
 }
 
-BaseError::BaseError(const std::string &message) {
-    what_str = "Error:\n" + message;
+BaseError::BaseError(const std::string &initMessage) {
+    message = "Error:\n" + initMessage;
 }
 
 const char *BaseError::what() const noexcept {
-    return what_str.c_str();
+    return message.data();
 }

--- a/compiler/tests/CMakeLists.txt
+++ b/compiler/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(ast)
 add_subdirectory(optree)
 add_subdirectory(frontend)
 add_subdirectory(backend)
+add_subdirectory(utils)
 
 add_custom_target(tests
 DEPENDS
@@ -12,6 +13,7 @@ DEPENDS
     frontend_test
     backend_ast_test
     backend_optree_test
+    utils_test
 )
 
 add_custom_target(run_tests
@@ -21,6 +23,7 @@ DEPENDS
     run_frontend_test
     run_backend_ast_test
     run_backend_optree_test
+    run_utils_test
 )
 
 add_subdirectory(codegen)

--- a/compiler/tests/utils/CMakeLists.txt
+++ b/compiler/tests/utils/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.22)
+
+set(TARGET_NAME utils_test)
+
+file(GLOB_RECURSE TARGET_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+)
+
+add_executable(${TARGET_NAME} ${TARGET_SRC})
+
+target_include_directories(${TARGET_NAME} PUBLIC
+    ${COMPILER_INCLUDE_DIR}
+)
+
+target_link_libraries(${TARGET_NAME} PUBLIC
+    utils
+    gtest
+    gtest_main
+)
+
+gtest_discover_tests(${TARGET_NAME})
+
+add_custom_target(run_utils_test
+    COMMAND $<TARGET_FILE:utils_test>
+    DEPENDS utils_test
+    COMMENT "Run utility tests"
+)

--- a/compiler/tests/utils/base_error.cpp
+++ b/compiler/tests/utils/base_error.cpp
@@ -1,0 +1,79 @@
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "compiler/utils/base_error.hpp"
+#include "compiler/utils/source_ref.hpp"
+
+using namespace utils;
+
+namespace {
+
+class Dumpable {
+    std::string data;
+
+  public:
+    explicit Dumpable(const std::string &data) : data(data) {
+    }
+    ~Dumpable() = default;
+
+    std::string dump() const {
+        return data;
+    }
+};
+
+class TestError : public BaseError {
+  public:
+    TestError() = default;
+    ~TestError() = default;
+};
+
+} // namespace
+
+TEST(BaseError, can_construct_default) {
+    ASSERT_NO_THROW(BaseError error);
+}
+
+TEST(BaseError, can_construct_from_message) {
+    std::string message = "Hello world";
+    BaseError error(message);
+    ASSERT_STREQ(error.what(), "Error:\nHello world");
+}
+
+TEST(BaseError, can_construct_from_source_ref_and_message) {
+    SourceRef ref(nullptr, 0, 0);
+    std::string message = "Hello world";
+    BaseError error(ref, message);
+    ASSERT_STREQ(error.what(), "In line 0 in column 0 error:\nHello world");
+}
+
+TEST(BaseError, can_append_strings) {
+    BaseError error;
+    error << std::string("Hello world") << "123";
+    ASSERT_STREQ(error.what(), "Error:\nHello world123");
+}
+
+TEST(BaseError, can_append_via_to_string) {
+    BaseError error;
+    error << -5 << 779U;
+    ASSERT_STREQ(error.what(), "Error:\n-5779");
+}
+
+TEST(BaseError, can_append_via_dump) {
+    BaseError error;
+    error << Dumpable("Dumped");
+    ASSERT_STREQ(error.what(), "Error:\nDumped");
+}
+
+TEST(BaseError, can_append_via_dump_ptr) {
+    BaseError error;
+    error << std::make_unique<Dumpable>("Dumped");
+    ASSERT_STREQ(error.what(), "Error:\nDumped");
+}
+
+TEST(BaseError, can_append_on_derived_class) {
+    TestError error;
+    error << "TestError" << 3;
+    ASSERT_STREQ(error.what(), "Error:\nTestError3");
+}

--- a/compiler/tests/utils/main.cpp
+++ b/compiler/tests/utils/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char *argv[]) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Diagnostic message of BaseError class (and its derivatives) instances can be appended with stream-like syntax. To conveniently utilize this feature, ErrorBuffer::push method now returns a pointer to new instance.