### PR TITLE
Allow Type objects to be dumped via BaseError operator<<

### DIFF
--- a/compiler/include/compiler/optree/types.hpp
+++ b/compiler/include/compiler/optree/types.hpp
@@ -21,14 +21,12 @@ struct Type {
     Type &operator=(const Type &) = default;
     Type &operator=(Type &&) = default;
 
-    template <typename DerivedType>
-        requires std::derived_from<DerivedType, Type>
+    template <std::derived_from<Type> DerivedType>
     bool is() const {
         return dynamic_cast<const std::remove_cvref_t<DerivedType> *>(this) != nullptr;
     }
 
-    template <typename DerivedType>
-        requires std::derived_from<DerivedType, Type>
+    template <std::derived_from<Type> DerivedType>
     const std::remove_cvref_t<DerivedType> &as() const {
         return dynamic_cast<const std::remove_cvref_t<DerivedType> &>(*this);
     }
@@ -47,6 +45,7 @@ struct Type {
 
     virtual unsigned bitWidth() const;
     virtual void dump(std::ostream &stream) const;
+    virtual std::string dump() const;
 
     template <typename ConcreteType, typename... Args>
     static auto make(Args... args) {

--- a/compiler/include/compiler/utils/base_error.hpp
+++ b/compiler/include/compiler/utils/base_error.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include "compiler/utils/source_ref.hpp"
 
@@ -19,15 +21,15 @@ class BaseError : public std::exception {
     virtual const char *what() const noexcept;
 
     template <typename T>
-        requires std::same_as<decltype(message + std::declval<T>()), std::string>
+        requires std::same_as<decltype(message += std::declval<T>()), std::string &> && (!std::integral<T>)
     BaseError &operator<<(const T &value) {
         message += value;
         return *this;
     }
 
     template <typename T>
-        requires std::same_as<decltype(message + std::to_string(std::declval<T>())), std::string>
-    BaseError &operator<<(const T &value) {
+        requires std::same_as<decltype(std::to_string(std::declval<T>())), std::string>
+    BaseError &operator<<(T value) {
         message += std::to_string(value);
         return *this;
     }

--- a/compiler/include/compiler/utils/base_error.hpp
+++ b/compiler/include/compiler/utils/base_error.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <sstream>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 
 #include "compiler/utils/source_ref.hpp"
 

--- a/compiler/lib/optree/types.cpp
+++ b/compiler/lib/optree/types.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <ostream>
+#include <sstream>
+#include <string>
 #include <unordered_map>
 
 #include "compiler/utils/helpers.hpp"
@@ -28,6 +30,12 @@ unsigned Type::bitWidth() const {
 
 void Type::dump(std::ostream &stream) const {
     stream << "<<NULL TYPE>>";
+}
+
+std::string Type::dump() const {
+    std::stringstream str;
+    dump(str);
+    return str.str();
 }
 
 bool NoneType::operator==(const Type &other) const {


### PR DESCRIPTION
`Type` class interface was lacking `std::string dump() const` method. Also, to resolve overload ambiguity in favor of `std::to_string` approach for dumping integers, an additional constraint was added to `BaseError::operator<<` declaration.