### PR TITLE
Consider adaptor classes inheritance relations within RTTI

### DIFF
--- a/compiler/include/compiler/optree/base_adaptor.hpp
+++ b/compiler/include/compiler/optree/base_adaptor.hpp
@@ -6,14 +6,18 @@
 #include "compiler/utils/source_ref.hpp"
 
 #define OPTREE_ADAPTOR_HELPER(BASE_ADAPTOR_CLASS, OPERATION_NAME)                                                      \
-    using BASE_ADAPTOR_CLASS::BASE_ADAPTOR_CLASS;                                                                      \
-    using BASE_ADAPTOR_CLASS::operator bool;                                                                           \
+    using Base = BASE_ADAPTOR_CLASS;                                                                                   \
+    using Base::Base;                                                                                                  \
+    using Base::operator bool;                                                                                         \
     static std::string_view getOperationName() {                                                                       \
         return (OPERATION_NAME);                                                                                       \
     }                                                                                                                  \
     static Operation::SpecId getSpecId() {                                                                             \
         static char specId = 0;                                                                                        \
         return &specId;                                                                                                \
+    }                                                                                                                  \
+    static bool implementsSpecById(Operation::SpecId specId) {                                                         \
+        return specId == getSpecId() || Base::implementsSpecById(specId);                                              \
     }
 
 #define OPTREE_ADAPTOR_ATTRIBUTE(GET_NAME, SET_NAME, TYPE, NUMBER)                                                     \
@@ -88,6 +92,10 @@ struct Adaptor {
 
     static Operation::SpecId getSpecId() {
         return nullptr;
+    }
+
+    static bool implementsSpecById(Operation::SpecId) {
+        return false;
     }
 };
 

--- a/compiler/include/compiler/optree/operation.hpp
+++ b/compiler/include/compiler/optree/operation.hpp
@@ -130,7 +130,7 @@ struct Operation : public std::enable_shared_from_this<Operation> {
 
     template <typename AdaptorType>
     bool is() const {
-        return specId == AdaptorType::getSpecId();
+        return AdaptorType::implementsSpecById(specId);
     }
 
     template <typename AdaptorType>

--- a/compiler/tests/optree/base_adaptor.cpp
+++ b/compiler/tests/optree/base_adaptor.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include "compiler/optree/base_adaptor.hpp"
+
+using namespace optree;
+
+namespace {
+
+struct ColorOp : Adaptor {
+    OPTREE_ADAPTOR_HELPER(Adaptor, "Color")
+};
+
+struct RedColorOp : ColorOp {
+    OPTREE_ADAPTOR_HELPER(ColorOp, "RedColor")
+};
+
+struct AnimalOp : Adaptor {
+    OPTREE_ADAPTOR_HELPER(Adaptor, "Animal")
+};
+
+struct CatOp : AnimalOp {
+    OPTREE_ADAPTOR_HELPER(AnimalOp, "Cat")
+};
+
+} // namespace
+
+TEST(BaseAdaptor, can_check_implements_own_spec) {
+    ColorOp op1;
+    RedColorOp op2;
+    AnimalOp op3;
+    CatOp op4;
+    ASSERT_TRUE(op1.implementsSpecById(ColorOp::getSpecId()));
+    ASSERT_TRUE(op2.implementsSpecById(RedColorOp::getSpecId()));
+    ASSERT_TRUE(op3.implementsSpecById(AnimalOp::getSpecId()));
+    ASSERT_TRUE(op4.implementsSpecById(CatOp::getSpecId()));
+}
+
+TEST(BaseAdaptor, can_check_not_implement_other_spec) {
+    ColorOp op1;
+    RedColorOp op2;
+    AnimalOp op3;
+    CatOp op4;
+    ASSERT_FALSE(op1.implementsSpecById(RedColorOp::getSpecId()));
+    ASSERT_FALSE(op2.implementsSpecById(AnimalOp::getSpecId()));
+    ASSERT_FALSE(op3.implementsSpecById(CatOp::getSpecId()));
+    ASSERT_FALSE(op4.implementsSpecById(ColorOp::getSpecId()));
+}
+
+TEST(BaseAdaptor, can_check_derived_implements_base_spec) {
+    RedColorOp op1;
+    CatOp op2;
+    ASSERT_TRUE(op1.implementsSpecById(ColorOp::getSpecId()));
+    ASSERT_TRUE(op2.implementsSpecById(AnimalOp::getSpecId()));
+}


### PR DESCRIPTION
By design, calls to `is<BaseOp>()` on operations which have spec of one of BaseOp derivatives should return `true`.