### PR TITLE
Re-organize platform-dependent implementations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,7 +34,6 @@ Checks: >
   misc-unused-using-decls,
   misc-use-anonymous-namespace,
   modernize-avoid-c-arrays,
-  modernize-deprecated-headers,
   modernize-loop-convert,
   modernize-make-shared,
   modernize-make-unique,

--- a/compiler/include/compiler/utils/debug.hpp
+++ b/compiler/include/compiler/utils/debug.hpp
@@ -15,6 +15,7 @@
 #define COMPILER_DEBUG(STATEMENT) STATEMENT
 #endif
 
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define COMPILER_DEBUG_PRINT(SUBEXPR) COMPILER_DEBUG(::utils::DebugPrinter::get() << SUBEXPR)
 
 #if defined(COMPILER_TOOLCHAIN_MSVC)

--- a/compiler/include/compiler/utils/debug.hpp
+++ b/compiler/include/compiler/utils/debug.hpp
@@ -7,10 +7,30 @@
 #include <iostream>
 #include <string>
 
+#include "compiler/utils/platform.hpp"
+
 #if defined(NDEBUG) && !defined(DEBUG)
-#define COMPILER_DEBUG(STATEMENT)
+#define COMPILER_DEBUG(...)
 #else
 #define COMPILER_DEBUG(STATEMENT) STATEMENT
+#endif
+
+#define COMPILER_DEBUG_PRINT(SUBEXPR) COMPILER_DEBUG(::utils::DebugPrinter::get() << SUBEXPR)
+
+#if defined(COMPILER_TOOLCHAIN_MSVC)
+#define COMPILER_UNREACHABLE(MESSAGE)                                                                                  \
+    do {                                                                                                               \
+        COMPILER_DEBUG_PRINT("UNREACHABLE: " << (MESSAGE) << '\n');                                                    \
+        __assume(false);                                                                                               \
+    } while (0)
+#elif defined(COMPILER_TOOLCHAIN_GCC_COMPATIBLE)
+#define COMPILER_UNREACHABLE(MESSAGE)                                                                                  \
+    do {                                                                                                               \
+        COMPILER_DEBUG_PRINT("UNREACHABLE: " << (MESSAGE) << '\n');                                                    \
+        __builtin_unreachable();                                                                                       \
+    } while (0)
+#else
+#define COMPILER_UNREACHABLE(MESSAGE) COMPILER_DEBUG_PRINT("UNREACHABLE: " << (MESSAGE) << '\n')
 #endif
 
 namespace utils {

--- a/compiler/include/compiler/utils/helpers.hpp
+++ b/compiler/include/compiler/utils/helpers.hpp
@@ -8,20 +8,6 @@
 #include <type_traits>
 #include <variant>
 
-#if defined(_MSC_VER) && !defined(__clang__) // MSVC
-#define COMPILER_UNREACHABLE(MESSAGE)                                                                                  \
-    do {                                                                                                               \
-        assert(false && (MESSAGE));                                                                                    \
-        __assume(false);                                                                                               \
-    } while (0)
-#else // GCC, Clang
-#define COMPILER_UNREACHABLE(MESSAGE)                                                                                  \
-    do {                                                                                                               \
-        assert(false && (MESSAGE));                                                                                    \
-        __builtin_unreachable();                                                                                       \
-    } while (0)
-#endif
-
 namespace utils {
 
 namespace detail {

--- a/compiler/include/compiler/utils/platform.hpp
+++ b/compiler/include/compiler/utils/platform.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#if defined(__linux__)
+#define COMPILER_PLATFORM_LINUX 1
+#elif defined(_WIN32)
+#define COMPILER_PLATFORM_WINDOWS 1
+#else
+#error "Unsupported platform. Supported platforms are: Linux, Windows."
+#endif
+
+#if defined(__clang__) || defined(__llvm__)
+#define COMPILER_TOOLCHAIN_CLANG 1
+#define COMPILER_TOOLCHAIN_GCC_COMPATIBLE 1
+#elif defined(__GNUC__)
+#define COMPILER_TOOLCHAIN_GCC 1
+#define COMPILER_TOOLCHAIN_GCC_COMPATIBLE 1
+#elif defined(_MSC_VER)
+#define COMPILER_TOOLCHAIN_MSVC 1
+#else
+#error "Unsupported toolchain. Supported toolchains are: clang, gcc, msvc."
+#endif
+
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+#define COMPILER_ARCH_X86 1
+#elif defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARMT)
+#define COMPILER_ARCH_ARM 1
+#else
+#error "Unsupported architecture. Supported architectures are: x86, ARM."
+#endif

--- a/compiler/lib/backend/optree/optimizer/transforms/fold_constants.cpp
+++ b/compiler/lib/backend/optree/optimizer/transforms/fold_constants.cpp
@@ -6,7 +6,7 @@
 #include "compiler/optree/helpers.hpp"
 #include "compiler/optree/operation.hpp"
 #include "compiler/optree/types.hpp"
-#include "compiler/utils/helpers.hpp"
+#include "compiler/utils/debug.hpp"
 
 #include "optimizer/opt_builder.hpp"
 #include "optimizer/transform.hpp"

--- a/compiler/lib/backend/optree/semantizer/semantizer.cpp
+++ b/compiler/lib/backend/optree/semantizer/semantizer.cpp
@@ -12,7 +12,7 @@
 #include "compiler/optree/program.hpp"
 #include "compiler/optree/types.hpp"
 #include "compiler/optree/value.hpp"
-#include "compiler/utils/helpers.hpp"
+#include "compiler/utils/debug.hpp"
 
 #include "semantizer/semantizer_context.hpp"
 #include "semantizer/traits.hpp"

--- a/compiler/lib/cli/compiler.cpp
+++ b/compiler/lib/cli/compiler.cpp
@@ -22,8 +22,8 @@
 #include "compiler/frontend/lexer/lexer.hpp"
 #include "compiler/frontend/parser/parser.hpp"
 #include "compiler/frontend/preprocessor/preprocessor.hpp"
+#include "compiler/utils/debug.hpp"
 #include "compiler/utils/error_buffer.hpp"
-#include "compiler/utils/helpers.hpp"
 #include "compiler/utils/source_files.hpp"
 #include "compiler/utils/timer.hpp"
 

--- a/compiler/lib/cli/helpers.cpp
+++ b/compiler/lib/cli/helpers.cpp
@@ -9,10 +9,10 @@
 
 #if defined(COMPILER_PLATFORM_WINDOWS)
 #include <array>
-#include <stdio.h>
+#include <cstdio> // NOLINT(misc-include-cleaner)
 #include <string_view>
 #elif defined(COMPILER_PLATFORM_LINUX)
-#include <stdlib.h>
+#include <cstdlib> // NOLINT(misc-include-cleaner)
 #endif
 
 namespace cli {

--- a/compiler/lib/cli/helpers.cpp
+++ b/compiler/lib/cli/helpers.cpp
@@ -9,10 +9,10 @@
 
 #if defined(COMPILER_PLATFORM_WINDOWS)
 #include <array>
-#include <cstdio>
+#include <stdio.h>
 #include <string_view>
 #elif defined(COMPILER_PLATFORM_LINUX)
-#include <cstdlib>
+#include <stdlib.h>
 #endif
 
 namespace cli {

--- a/compiler/lib/cli/helpers.cpp
+++ b/compiler/lib/cli/helpers.cpp
@@ -9,10 +9,10 @@
 
 #if defined(COMPILER_PLATFORM_WINDOWS)
 #include <array>
-#include <cstdio> // NOLINT(misc-include-cleaner)
+#include <stdio.h> // NOLINT(misc-include-cleaner)
 #include <string_view>
 #elif defined(COMPILER_PLATFORM_LINUX)
-#include <cstdlib> // NOLINT(misc-include-cleaner)
+#include <stdlib.h> // NOLINT(misc-include-cleaner)
 #endif
 
 namespace cli {

--- a/compiler/lib/codegen/optree_to_llvmir/llvmir_generator.cpp
+++ b/compiler/lib/codegen/optree_to_llvmir/llvmir_generator.cpp
@@ -22,7 +22,7 @@
 #include "compiler/optree/program.hpp"
 #include "compiler/optree/types.hpp"
 #include "compiler/optree/value.hpp"
-#include "compiler/utils/helpers.hpp"
+#include "compiler/utils/debug.hpp"
 
 using namespace optree;
 using namespace optree::llvmir_generator;

--- a/compiler/lib/frontend/converter/converter.cpp
+++ b/compiler/lib/frontend/converter/converter.cpp
@@ -19,6 +19,7 @@
 #include "compiler/optree/program.hpp"
 #include "compiler/optree/types.hpp"
 #include "compiler/optree/value.hpp"
+#include "compiler/utils/debug.hpp"
 #include "compiler/utils/helpers.hpp"
 #include "compiler/utils/language.hpp"
 #include "compiler/utils/source_ref.hpp"


### PR DESCRIPTION
* Add `platform.hpp` header with utility macros regarding host platform, toolchain, architecture
* Move COMPILER_UNREACHABLE to debug utilities