### PR TITLE
Add `dynamicSizes` operand for AllocateOp

### DIFF
--- a/compiler/include/compiler/optree/adaptors.hpp
+++ b/compiler/include/compiler/optree/adaptors.hpp
@@ -154,9 +154,13 @@ struct StoreOp;
 struct AllocateOp : Adaptor {
     OPTREE_ADAPTOR_HELPER(Adaptor, "Allocate")
 
-    void init(const Type::Ptr &type);
+    void init(const Type::Ptr &type, const Value::Ptr &dynamicSize = {});
 
     OPTREE_ADAPTOR_RESULT(result, 0)
+
+    // dynamicSize is an optional operand
+    Value::Ptr dynamicSize() const;
+    void setDynamicSize(const Value::Ptr &value);
 };
 
 struct LoadOp : Adaptor {

--- a/compiler/include/compiler/optree/types.hpp
+++ b/compiler/include/compiler/optree/types.hpp
@@ -138,6 +138,7 @@ struct FunctionType : public Type {
 
 struct PointerType : public Type {
     using Ptr = std::shared_ptr<const PointerType>;
+    static inline constexpr size_t dynamic = 0U;
 
     const Type::Ptr pointee;
     size_t numElements;

--- a/compiler/lib/codegen/optree_to_llvmir/llvmir_generator.cpp
+++ b/compiler/lib/codegen/optree_to_llvmir/llvmir_generator.cpp
@@ -346,7 +346,9 @@ void LLVMIRGenerator::visit(const AllocateOp &op) {
     const auto &type = op.result()->type->as<PointerType>();
     auto *llvmType = convertType(type.pointee);
     llvm::Value *size = nullptr;
-    if (type.numElements > 1U)
+    if (type.numElements == PointerType::dynamic)
+        size = findValue(op.dynamicSize());
+    else if (type.numElements > 1U)
         size = llvm::ConstantInt::get(llvm::Type::getIntNTy(context, 64U), type.numElements);
     auto *inst = builder.CreateAlloca(llvmType, size);
     saveValue(op.result(), inst);

--- a/compiler/lib/optree/adaptors.cpp
+++ b/compiler/lib/optree/adaptors.cpp
@@ -12,8 +12,23 @@ using namespace optree;
 
 // The following definitions for the methods of the operation classes should be arranged in alphabetical order.
 
-void AllocateOp::init(const Type::Ptr &type) {
+void AllocateOp::init(const Type::Ptr &type, const Value::Ptr &dynamicSize) {
     op->results.emplace_back(Value::make(type, op));
+    if (dynamicSize)
+        op->addOperand(dynamicSize);
+}
+
+Value::Ptr AllocateOp::dynamicSize() const {
+    if (op->numOperands() == 1)
+        return op->operand(0);
+    return {};
+}
+
+void AllocateOp::setDynamicSize(const Value::Ptr &value) {
+    if (op->numOperands() == 1)
+        op->operand(0) = value;
+    else
+        op->addOperand(value);
 }
 
 void ArithBinaryOp::init(ArithBinOpKind kind, const Type::Ptr &resultType, const Value::Ptr &lhs,


### PR DESCRIPTION
Support `dynamicSizes` in LLVM IR codegen