### PR TITLE
Refactor ast::Node (add numChildren method, use in64_t)

### DIFF
--- a/compiler/include/compiler/ast/node.hpp
+++ b/compiler/include/compiler/ast/node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <ostream>
@@ -16,16 +17,16 @@ namespace ast {
 
 struct Node {
     using Ptr = std::shared_ptr<Node>;
-    using WeakPtr = std::weak_ptr<Node>;
+    using ValueStorage =
+        std::variant<int64_t, double, bool, std::string, TypeId, BinaryOperation, UnaryOperation, VariablesTable>;
 
     std::list<Ptr> children;
     Ptr parent;
-
     utils::SourceRef ref;
 
     /**
      * value type      : node type
-     * long int        : IntegerLiteralValue
+     * int64_t         : IntegerLiteralValue
      * double          : FloatingPointLiteralValue
      * bool            : BooleanLiteralValue
      * std::string     : StringLiteralValue, FunctionName, VariableName
@@ -36,93 +37,42 @@ struct Node {
      * nothing         : other types
      */
     NodeType type;
-    std::variant<long int, double, bool, std::string, TypeId, BinaryOperation, UnaryOperation, VariablesTable> value;
-
-    const long int &intNum() const {
-        return std::get<long int>(value);
-    }
-    const double &fpNum() const {
-        return std::get<double>(value);
-    }
-    const bool &boolean() const {
-        return std::get<bool>(value);
-    }
-    const std::string &str() const {
-        return std::get<std::string>(value);
-    }
-    const TypeId &typeId() const {
-        return std::get<TypeId>(value);
-    }
-    const BinaryOperation &binOp() const {
-        return std::get<BinaryOperation>(value);
-    }
-    const UnaryOperation &unOp() const {
-        return std::get<UnaryOperation>(value);
-    }
-    const VariablesTable &variables() const {
-        return std::get<VariablesTable>(value);
-    }
-    VariablesTable &variables() {
-        return std::get<VariablesTable>(value);
-    }
-
-    bool operator==(const Node &other) const {
-        if (children.size() != other.children.size())
-            return false;
-        if (children.size() > 0) {
-            for (auto i = children.begin(), j = other.children.begin(); i != children.end(); i++, j++)
-                if (**i != **j)
-                    return false;
-        }
-        return type == other.type && value == other.value;
-    }
-
-    bool operator!=(const Node &other) const {
-        return !(*this == other);
-    }
+    ValueStorage value;
 
     Node() = default;
     ~Node() = default;
 
-    explicit Node(const NodeType &type_, Ptr parent_ = Ptr()) : type(type_), parent(parent_){};
-    explicit Node(long int intNum_, Ptr parent_ = Ptr())
-        : type(NodeType::IntegerLiteralValue), value(intNum_), parent(parent_){};
-    explicit Node(double fpNum_, Ptr parent_ = Ptr())
-        : type(NodeType::FloatingPointLiteralValue), value(fpNum_), parent(parent_){};
-    Node(const NodeType &type_, const std::string &str_, Ptr parent_ = Ptr())
-        : type(type_), value(str_), parent(parent_){};
-    explicit Node(TypeId typeId_, Ptr parent_ = Ptr()) : type(NodeType::TypeName), value(typeId_), parent(parent_){};
-    explicit Node(BinaryOperation binOp_, Ptr parent_ = Ptr())
-        : type(NodeType::BinaryOperation), value(binOp_), parent(parent_){};
-    explicit Node(UnaryOperation unOp_, Ptr parent_ = Ptr())
-        : type(NodeType::UnaryOperation), value(unOp_), parent(parent_){};
+    explicit Node(const NodeType &type, const Ptr &parent = {});
+    explicit Node(int64_t intNum, const Ptr &parent = {});
+    explicit Node(double fpNum, const Ptr &parent = {});
+    explicit Node(const NodeType &type, const std::string &str, const Ptr &parent = {});
+    explicit Node(TypeId typeId, const Ptr &parent = {});
+    explicit Node(BinaryOperation binOp, const Ptr &parent = {});
+    explicit Node(UnaryOperation unOp, const Ptr &parent = {});
+
+    const int64_t &intNum() const;
+    const double &fpNum() const;
+    const bool &boolean() const;
+    const std::string &str() const;
+    const TypeId &typeId() const;
+    const BinaryOperation &binOp() const;
+    const UnaryOperation &unOp() const;
+    const VariablesTable &variables() const;
+    VariablesTable &variables();
+
+    bool operator==(const Node &other) const;
+    bool operator!=(const Node &other) const;
+
+    Ptr &firstChild();
+    const Ptr &firstChild() const;
+    Ptr &secondChild();
+    const Ptr &secondChild() const;
+    Ptr &lastChild();
+    const Ptr &lastChild() const;
+    size_t numChildren() const;
 
     std::string dump(int depth = 0) const;
     void dump(std::ostream &stream, int depth = 0) const;
-
-    Node::Ptr &firstChild() {
-        return children.front();
-    }
-
-    const Node::Ptr &firstChild() const {
-        return children.front();
-    }
-
-    Node::Ptr &secondChild() {
-        return *std::next(children.begin());
-    }
-
-    const Node::Ptr &secondChild() const {
-        return *std::next(children.begin());
-    }
-
-    Node::Ptr &lastChild() {
-        return children.back();
-    }
-
-    const Node::Ptr &lastChild() const {
-        return children.back();
-    }
 };
 
 } // namespace ast

--- a/compiler/include/compiler/ast/node.hpp
+++ b/compiler/include/compiler/ast/node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <list>
 #include <memory>

--- a/compiler/include/compiler/backend/ast/optimizer/optimizer_context.hpp
+++ b/compiler/include/compiler/backend/ast/optimizer/optimizer_context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <forward_list>
 #include <stdexcept>
 #include <string>
@@ -14,7 +15,7 @@
 
 namespace optimizer {
 
-using VariableValue = std::variant<long int, double>;
+using VariableValue = std::variant<int64_t, double>;
 
 struct OptimizerContext {
     std::forward_list<ast::VariablesTable *> variables;
@@ -23,8 +24,8 @@ struct OptimizerContext {
     ast::Node::Ptr root;
     OptimizerOptions options;
 
-    OptimizerContext(ast::FunctionsTable &functions_, const OptimizerOptions &options_)
-        : variables(), values(), functions(functions_), options(options_){};
+    OptimizerContext(ast::FunctionsTable &functions, const OptimizerOptions &options)
+        : variables(), values(), functions(functions), options(options){};
 
     ast::Variable &findVariable(const std::string &name) {
         for (auto &table : variables) {

--- a/compiler/lib/ast/node.cpp
+++ b/compiler/lib/ast/node.cpp
@@ -1,10 +1,15 @@
 #include "node.hpp"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <iterator>
 #include <sstream>
+#include <string>
 
 #include "node_type.hpp"
 #include "types.hpp"
+#include "variables_table.hpp"
 
 using namespace ast;
 

--- a/compiler/lib/ast/node.cpp
+++ b/compiler/lib/ast/node.cpp
@@ -107,19 +107,26 @@ void dumpVariablesTable(std::ostream &stream, const VariablesTable &table) {
 
 } // namespace
 
-Node::Node(const NodeType &type, const Ptr &parent) : type(type), parent(parent){};
+Node::Node(const NodeType &type, const Ptr &parent) : type(type), parent(parent) {
+}
 
-Node::Node(int64_t intNum, const Ptr &parent) : type(NodeType::IntegerLiteralValue), value(intNum), parent(parent){};
+Node::Node(int64_t intNum, const Ptr &parent) : type(NodeType::IntegerLiteralValue), value(intNum), parent(parent) {
+}
 
-Node::Node(double fpNum, const Ptr &parent) : type(NodeType::FloatingPointLiteralValue), value(fpNum), parent(parent){};
+Node::Node(double fpNum, const Ptr &parent) : type(NodeType::FloatingPointLiteralValue), value(fpNum), parent(parent) {
+}
 
-Node::Node(const NodeType &type, const std::string &str, const Ptr &parent) : type(type), value(str), parent(parent){};
+Node::Node(const NodeType &type, const std::string &str, const Ptr &parent) : type(type), value(str), parent(parent) {
+}
 
-Node::Node(TypeId typeId, const Ptr &parent) : type(NodeType::TypeName), value(typeId), parent(parent){};
+Node::Node(TypeId typeId, const Ptr &parent) : type(NodeType::TypeName), value(typeId), parent(parent) {
+}
 
-Node::Node(BinaryOperation binOp, const Ptr &parent) : type(NodeType::BinaryOperation), value(binOp), parent(parent){};
+Node::Node(BinaryOperation binOp, const Ptr &parent) : type(NodeType::BinaryOperation), value(binOp), parent(parent) {
+}
 
-Node::Node(UnaryOperation unOp, const Ptr &parent) : type(NodeType::UnaryOperation), value(unOp), parent(parent){};
+Node::Node(UnaryOperation unOp, const Ptr &parent) : type(NodeType::UnaryOperation), value(unOp), parent(parent) {
+}
 
 const int64_t &Node::intNum() const {
     return std::get<int64_t>(value);

--- a/compiler/lib/ast/node.cpp
+++ b/compiler/lib/ast/node.cpp
@@ -10,7 +10,7 @@ using namespace ast;
 
 namespace {
 
-const char *const binaryOperationToString(BinaryOperation binOp) {
+const char *binaryOperationToString(BinaryOperation binOp) {
     switch (binOp) {
     case BinaryOperation::Add:
         return "Add";
@@ -65,7 +65,7 @@ const char *const binaryOperationToString(BinaryOperation binOp) {
     }
 }
 
-const char *const unaryOperationToString(UnaryOperation unOp) {
+const char *unaryOperationToString(UnaryOperation unOp) {
     switch (unOp) {
     case UnaryOperation::Not:
         return "Not";
@@ -77,7 +77,7 @@ const char *const unaryOperationToString(UnaryOperation unOp) {
     return "";
 }
 
-const char *const typeIdToString(TypeId typeId) {
+const char *typeIdToString(TypeId typeId) {
     switch (typeId) {
     case IntType:
         return "IntType";
@@ -101,6 +101,99 @@ void dumpVariablesTable(std::ostream &stream, const VariablesTable &table) {
 }
 
 } // namespace
+
+Node::Node(const NodeType &type, const Ptr &parent) : type(type), parent(parent){};
+
+Node::Node(int64_t intNum, const Ptr &parent) : type(NodeType::IntegerLiteralValue), value(intNum), parent(parent){};
+
+Node::Node(double fpNum, const Ptr &parent) : type(NodeType::FloatingPointLiteralValue), value(fpNum), parent(parent){};
+
+Node::Node(const NodeType &type, const std::string &str, const Ptr &parent) : type(type), value(str), parent(parent){};
+
+Node::Node(TypeId typeId, const Ptr &parent) : type(NodeType::TypeName), value(typeId), parent(parent){};
+
+Node::Node(BinaryOperation binOp, const Ptr &parent) : type(NodeType::BinaryOperation), value(binOp), parent(parent){};
+
+Node::Node(UnaryOperation unOp, const Ptr &parent) : type(NodeType::UnaryOperation), value(unOp), parent(parent){};
+
+const int64_t &Node::intNum() const {
+    return std::get<int64_t>(value);
+}
+
+const double &Node::fpNum() const {
+    return std::get<double>(value);
+}
+
+const bool &Node::boolean() const {
+    return std::get<bool>(value);
+}
+
+const std::string &Node::str() const {
+    return std::get<std::string>(value);
+}
+
+const TypeId &Node::typeId() const {
+    return std::get<TypeId>(value);
+}
+
+const BinaryOperation &Node::binOp() const {
+    return std::get<BinaryOperation>(value);
+}
+
+const UnaryOperation &Node::unOp() const {
+    return std::get<UnaryOperation>(value);
+}
+
+const VariablesTable &Node::variables() const {
+    return std::get<VariablesTable>(value);
+}
+
+VariablesTable &Node::variables() {
+    return std::get<VariablesTable>(value);
+}
+
+bool Node::operator==(const Node &other) const {
+    if (numChildren() != other.numChildren())
+        return false;
+    if (numChildren() > 0) {
+        for (auto i = children.begin(), j = other.children.begin(); i != children.end(); i++, j++)
+            if (**i != **j)
+                return false;
+    }
+    return type == other.type && value == other.value;
+}
+
+bool Node::operator!=(const Node &other) const {
+    return !(*this == other);
+}
+
+Node::Ptr &Node::firstChild() {
+    return children.front();
+}
+
+const Node::Ptr &Node::firstChild() const {
+    return children.front();
+}
+
+Node::Ptr &Node::secondChild() {
+    return *std::next(children.begin());
+}
+
+const Node::Ptr &Node::secondChild() const {
+    return *std::next(children.begin());
+}
+
+Node::Ptr &Node::lastChild() {
+    return children.back();
+}
+
+const Node::Ptr &Node::lastChild() const {
+    return children.back();
+}
+
+size_t Node::numChildren() const {
+    return children.size();
+}
 
 void Node::dump(std::ostream &stream, int depth) const {
     for (int i = 0; i < depth; i++)

--- a/compiler/lib/backend/ast/semantizer/semantizer.cpp
+++ b/compiler/lib/backend/ast/semantizer/semantizer.cpp
@@ -156,7 +156,7 @@ static TypeId processFunctionCall(Node::Ptr &node, SemantizerContext &ctx) {
         }
     }
 
-    if (node->children.size() >= 2u) {
+    if (node->numChildren() >= 2U) {
         const std::vector<TypeId> &args = funcIter->second.argumentsTypes;
         size_t index = 0;
         for (auto &child : node->secondChild()->children) {

--- a/compiler/lib/codegen/ast_to_llvmir/ir_generator.cpp
+++ b/compiler/lib/codegen/ast_to_llvmir/ir_generator.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 
 #include "compiler/utils/language.hpp"
@@ -361,7 +362,7 @@ llvm::Value *IRGenerator::visitFunctionCall(Node *node) {
 llvm::Value *IRGenerator::visitIntegerLiteralValue(Node *node) {
     assert(node && node->type == NodeType::IntegerLiteralValue);
 
-    long value = node->intNum();
+    int64_t value = node->intNum();
     return llvm::ConstantInt::get(context, llvm::APInt(64, value, true));
 }
 
@@ -410,7 +411,7 @@ llvm::Value *IRGenerator::visitPrintFunctionCall(Node *node) {
     assert(node && node->type == NodeType::FunctionCall && node->firstChild()->str() == language::funcPrint);
 
     auto argsNode = node->lastChild();
-    assert(argsNode->children.size() == 1u); // print requires only one argument
+    assert(argsNode->numChildren() == 1U); // print requires only one argument
 
     auto valueNode = argsNode->firstChild();
     auto placeholderName = placeholderNameByTypeId(detectExpressionType(valueNode));
@@ -516,7 +517,7 @@ void IRGenerator::processIfStatement(Node *node) {
     llvm::BasicBlock *endBlock = llvm::BasicBlock::Create(context, "endif");
     llvm::BasicBlock *elseBlock = nullptr;
 
-    bool hasAdditionals = node->children.size() > 2u;
+    bool hasAdditionals = node->numChildren() > 2U;
     auto lastElse = node->lastChild();
 
     if (hasAdditionals && lastElse->type == NodeType::ElseStatement) {

--- a/compiler/lib/frontend/converter/converter.cpp
+++ b/compiler/lib/frontend/converter/converter.cpp
@@ -144,7 +144,7 @@ void processFunctionDefinition(const Node::Ptr &node, ConverterContext &ctx) {
         bool aggregate;
     };
     std::vector<ArgInfo> argsInfo;
-    argsInfo.reserve((*it)->children.size());
+    argsInfo.reserve((*it)->numChildren());
     for (const auto &argNode : (*it)->children) {
         auto typeId = argNode->firstChild()->typeId();
         bool aggregate = false;
@@ -189,7 +189,7 @@ void processVariableDeclaration(const Node::Ptr &node, ConverterContext &ctx) {
     const auto &typeNode = node->firstChild();
     Node::Ptr listNode;
     Type::Ptr type;
-    bool hasDefinition = node->children.size() == 3U;
+    bool hasDefinition = node->numChildren() == 3U;
     bool aggregate = false;
     if (typeNode->typeId() == ast::ListType) {
         aggregate = true;
@@ -200,7 +200,7 @@ void processVariableDeclaration(const Node::Ptr &node, ConverterContext &ctx) {
             // VariableDeclaration -> Expression -> ListStatement
             listNode = node->lastChild()->firstChild();
             assert(listNode->type == NodeType::ListStatement && "ListType variable must be defined with ListStatement");
-            size_t numChildren = listNode->children.size();
+            size_t numChildren = listNode->numChildren();
             if (listNode->lastChild()->type == NodeType::ListDynamicSize) {
                 if (numChildren != 2)
                     ctx.pushError(node, "dynamically sized list must have exactly one initializer: " + name);
@@ -283,7 +283,7 @@ void processWhileStatement(const Node::Ptr &node, ConverterContext &ctx) {
 
 void processIfStatement(const Node::Ptr &node, ConverterContext &ctx) {
     auto cond = visitNode(node->firstChild(), ctx);
-    bool withElse = node->children.size() > 2;
+    bool withElse = node->numChildren() > 2;
     auto ifOp = ctx.insert<IfOp>(node->ref, cond, withElse);
     ctx.goInto(ifOp.thenOp());
     processNode(node->secondChild(), ctx);
@@ -315,7 +315,7 @@ void processIfStatement(const Node::Ptr &node, ConverterContext &ctx) {
 
 void processForStatement(const Node::Ptr &node, ConverterContext &ctx) {
     const auto &targets = node->firstChild();
-    size_t numTargets = targets->children.size();
+    size_t numTargets = targets->numChildren();
     assert(numTargets != 0 && "parser ensures that there is at least one target");
     const auto &iterExpr = node->secondChild()->firstChild()->firstChild();
     // Process layout: for i in range(start, stop, step)
@@ -323,7 +323,7 @@ void processForStatement(const Node::Ptr &node, ConverterContext &ctx) {
         if (numTargets > 1)
             ctx.pushError(node, "for loop with range() must have exactly one target");
         const auto &argsNode = iterExpr->lastChild();
-        size_t numArgs = argsNode->children.size();
+        size_t numArgs = argsNode->numChildren();
         if (numArgs == 0) {
             ctx.pushError(argsNode, "range() must have at least one argument");
             return;
@@ -378,7 +378,7 @@ void processForStatement(const Node::Ptr &node, ConverterContext &ctx) {
         if (numTargets < 2)
             return;
         const auto &argsNode = iterExpr->lastChild();
-        if (argsNode->children.size() != 1) {
+        if (argsNode->numChildren() != 1U) {
             ctx.pushError(argsNode, "enumerate() must have exactly one argument");
             return;
         }
@@ -507,7 +507,7 @@ Value::Ptr visitBinaryOperation(const Node::Ptr &node, ConverterContext &ctx) {
             const auto &ptrType = lhsType->as<PointerType>();
             lhsType = ptrType.pointee;
             if (ptrType.numElements != 1U) {
-                assert(lhsNode->type == NodeType::ListAccessor && lhsNode->children.size() == 2U);
+                assert(lhsNode->type == NodeType::ListAccessor && lhsNode->numChildren() == 2U);
                 offset = visitNode(lhsNode->lastChild(), ctx);
             }
         } else {

--- a/compiler/lib/frontend/parser/parser.cpp
+++ b/compiler/lib/frontend/parser/parser.cpp
@@ -334,7 +334,7 @@ void buildExpressionSubtree(std::stack<SubExpression> &postfixForm, const Node::
             callNode->parent = currNode;
             currNode->children.push_front(callNode);
         }
-        while (currNode->children.size() >= getOperandCount(getOperationType(*currNode)))
+        while (currNode->numChildren() >= getOperandCount(getOperationType(*currNode)))
             currNode = currNode->parent;
         postfixForm.pop();
     }

--- a/compiler/tests/ast/node.cpp
+++ b/compiler/tests/ast/node.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <gtest/gtest.h>
 
 #include "compiler/ast/node.hpp"
@@ -5,7 +6,7 @@
 using namespace ast;
 
 TEST(Node, can_construct_with_integer_literal_value) {
-    long value = 1l;
+    int64_t value = 1l;
     Node node(value);
     ASSERT_EQ(value, node.intNum());
     ASSERT_EQ(NodeType::IntegerLiteralValue, node.type);


### PR DESCRIPTION
* Add numChildren method to be called instead of `node->children.size()`
* Use int64_t instead of long int everywhere
* Related refactoring (includes, unsigned suffixes, const &)