### PR TITLE
Add CMake option to enable debug statements

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -38,10 +38,15 @@ endif()
 option(ENABLE_CLI "Enables command-line interface application" ON)
 option(ENABLE_TESTS "Enables tests for components" ON)
 option(ENABLE_COVERAGE "Enables code coverage instrumentation" OFF)
+option(ENABLE_DEBUG "Enables debug statements forcefully" OFF)
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS_DEBUG "/MTd /Z7 /Od")
     option(gtest_force_shared_crt "" TRUE)
+endif()
+
+if (ENABLE_DEBUG)
+    add_compile_definitions(ENABLE_COMPILER_DEBUG)
 endif()
 
 include(${COMPILER_CMAKE_DIR}/utils.cmake)

--- a/compiler/include/compiler/utils/debug.hpp
+++ b/compiler/include/compiler/utils/debug.hpp
@@ -9,10 +9,10 @@
 
 #include "compiler/utils/platform.hpp"
 
-#if defined(ENABLE_COMPILER_DEBUG) || (defined(NDEBUG) && !defined(DEBUG))
-#define COMPILER_DEBUG(...)
-#else
+#if defined(ENABLE_COMPILER_DEBUG) || !defined(NDEBUG) || defined(DEBUG)
 #define COMPILER_DEBUG(STATEMENT) STATEMENT
+#else
+#define COMPILER_DEBUG(...)
 #endif
 
 // NOLINTNEXTLINE(bugprone-macro-parentheses)

--- a/compiler/include/compiler/utils/debug.hpp
+++ b/compiler/include/compiler/utils/debug.hpp
@@ -9,7 +9,7 @@
 
 #include "compiler/utils/platform.hpp"
 
-#if defined(NDEBUG) && !defined(DEBUG)
+#if defined(ENABLE_COMPILER_DEBUG) || (defined(NDEBUG) && !defined(DEBUG))
 #define COMPILER_DEBUG(...)
 #else
 #define COMPILER_DEBUG(STATEMENT) STATEMENT


### PR DESCRIPTION
Option `ENABLE_DEBUG` adds compiler definition `ENABLE_COMPILER_DEBUG` and enables `COMPILER_DEBUG` macro even for Release builds.